### PR TITLE
Make `leftwm-core` backend-agnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 dependencies = [
  "serde",
 ]
@@ -441,16 +441,6 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "gethostname"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
@@ -563,7 +553,7 @@ checksum = "b07050b037b9318d6e9e7e7ecb30faa46e716c6a13aa58105afacda1b3d6e950"
 dependencies = [
  "inventory",
  "mio",
- "nix 0.27.1",
+ "nix",
  "ron",
  "serde",
  "signal-hook",
@@ -615,11 +605,12 @@ dependencies = [
 name = "leftwm-core"
 version = "0.5.0"
 dependencies = [
+ "bitflags 2.4.2",
  "dirs-next",
  "futures",
  "leftwm-layouts",
  "mio",
- "nix 0.27.1",
+ "nix",
  "serde",
  "serde_json",
  "signal-hook",
@@ -627,8 +618,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "x11-dl",
- "x11rb 0.12.0",
  "xdg",
 ]
 
@@ -656,7 +645,7 @@ version = "0.5.1"
 dependencies = [
  "clap",
  "dirs-next",
- "nix 0.27.1",
+ "nix",
  "signal-hook",
  "tempfile",
  "thiserror",
@@ -675,7 +664,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "libc",
  "redox_syscall",
 ]
@@ -765,15 +754,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,23 +776,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cfg-if",
  "libc",
 ]
@@ -1046,7 +1014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "serde",
  "serde_derive",
 ]
@@ -1063,7 +1031,7 @@ version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1514,15 +1482,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-wsapoll"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,25 +1641,12 @@ dependencies = [
 
 [[package]]
 name = "x11rb"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a"
-dependencies = [
- "gethostname 0.3.0",
- "nix 0.26.4",
- "winapi",
- "winapi-wsapoll",
- "x11rb-protocol 0.12.0",
-]
-
-[[package]]
-name = "x11rb"
 version = "0.13.0"
 source = "git+https://github.com/psychon/x11rb#4b602657881fd66b4e6bc847fd8fe36ab653f570"
 dependencies = [
- "gethostname 0.4.3",
+ "gethostname",
  "rustix",
- "x11rb-protocol 0.13.0",
+ "x11rb-protocol",
 ]
 
 [[package]]
@@ -1710,18 +1656,10 @@ dependencies = [
  "futures",
  "leftwm-core",
  "mio",
+ "serde",
  "tokio",
  "tracing",
- "x11rb 0.13.0",
-]
-
-[[package]]
-name = "x11rb-protocol"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc"
-dependencies = [
- "nix 0.26.4",
+ "x11rb",
 ]
 
 [[package]]
@@ -1742,6 +1680,7 @@ dependencies = [
  "futures",
  "leftwm-core",
  "mio",
+ "serde",
  "tokio",
  "tracing",
  "x11-dl",

--- a/display-servers/x11rb-display-server/Cargo.toml
+++ b/display-servers/x11rb-display-server/Cargo.toml
@@ -16,3 +16,4 @@ mio = { version = "0.8.0", features = ["os-ext"] }
 # x11rb = { version = "0.12.0", features = ["cursor", "randr", "xinerama"] }
 # x11rb = { git = "https://github.com/Syudagye/x11rb", features = ["cursor", "randr", "xinerama"] }
 x11rb = { git = "https://github.com/psychon/x11rb", features = ["cursor", "randr", "xinerama"] }
+serde = { version = "1.0.104", features = ["derive"] }

--- a/display-servers/x11rb-display-server/src/event_translate/client_message.rs
+++ b/display-servers/x11rb-display-server/src/event_translate/client_message.rs
@@ -4,14 +4,14 @@ use leftwm_core::{
 };
 use x11rb::protocol::xproto;
 
-use crate::xwrap::XWrap;
+use crate::{xwrap::XWrap, X11rbWindowHandle};
 
 use crate::error::Result;
 
 pub(crate) fn from_event(
     event: xproto::ClientMessageEvent,
     xw: &XWrap,
-) -> Result<Option<DisplayEvent>> {
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     if !xw.managed_windows.contains(&event.window) && event.window != xw.get_default_root() {
         return Ok(None);
     }
@@ -45,7 +45,7 @@ pub(crate) fn from_event(
             Ok(index) => {
                 let event = DisplayEvent::SendCommand(Command::SendWindowToTag {
                     tag: index + 1,
-                    window: Some(WindowHandle::X11rbHandle(event.window)),
+                    window: Some(WindowHandle(X11rbWindowHandle(event.window))),
                 });
                 return Ok(Some(event));
             }
@@ -93,7 +93,7 @@ pub(crate) fn from_event(
         }
 
         // update the window states
-        let mut change = WindowChange::new(WindowHandle::X11rbHandle(event.window));
+        let mut change = WindowChange::new(WindowHandle(X11rbWindowHandle(event.window)));
         let states = xw.get_window_states(event.window)?;
         change.states = Some(states);
         return Ok(Some(DisplayEvent::WindowChange(change)));

--- a/display-servers/x11rb-display-server/src/lib.rs
+++ b/display-servers/x11rb-display-server/src/lib.rs
@@ -3,9 +3,10 @@
 //! TODO: Refactoring
 
 use leftwm_core::{
-    models::{Screen, TagId, WindowHandle, WindowState},
+    models::{Handle, Screen, TagId, WindowHandle, WindowState},
     Config, DisplayAction, DisplayEvent, DisplayServer, Mode, Window, Workspace,
 };
+use serde::{Deserialize, Serialize};
 use x11rb::protocol::xproto;
 
 use crate::xwrap::XWrap;
@@ -16,13 +17,17 @@ mod event_translate;
 mod xatom;
 mod xwrap;
 
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct X11rbWindowHandle(xproto::Window);
+impl Handle for X11rbWindowHandle {}
+
 pub struct X11rbDisplayServer {
     xw: XWrap,
     root: xproto::Window,
-    initial_events: Vec<DisplayEvent>,
+    initial_events: Vec<DisplayEvent<X11rbWindowHandle>>,
 }
 
-impl DisplayServer for X11rbDisplayServer {
+impl DisplayServer<X11rbWindowHandle> for X11rbDisplayServer {
     fn new(config: &impl Config) -> Self {
         let mut xwrap = XWrap::new();
 
@@ -42,15 +47,15 @@ impl DisplayServer for X11rbDisplayServer {
     fn load_config(
         &mut self,
         config: &impl Config,
-        focused: Option<&Option<WindowHandle>>,
-        windows: &[leftwm_core::Window],
+        focused: Option<&Option<WindowHandle<X11rbWindowHandle>>>,
+        windows: &[leftwm_core::Window<X11rbWindowHandle>],
     ) {
         if let Err(e) = self.xw.load_config(config, focused, windows) {
             tracing::error!("Error when loading config: {}", e);
         }
     }
 
-    fn update_windows(&self, windows: Vec<&Window>) {
+    fn update_windows(&self, windows: Vec<&Window<X11rbWindowHandle>>) {
         for window in &windows {
             if let Err(e) = self.xw.update_window(window) {
                 tracing::error!("Error when updating window {:?}: {}", window, e);
@@ -66,7 +71,7 @@ impl DisplayServer for X11rbDisplayServer {
         }
     }
 
-    fn get_next_events(&mut self) -> Vec<leftwm_core::DisplayEvent> {
+    fn get_next_events(&mut self) -> Vec<leftwm_core::DisplayEvent<X11rbWindowHandle>> {
         let mut events = std::mem::take(&mut self.initial_events);
 
         loop {
@@ -85,7 +90,7 @@ impl DisplayServer for X11rbDisplayServer {
         }
 
         for event in &events {
-            if let DisplayEvent::WindowDestroy(WindowHandle::X11rbHandle(w)) = event {
+            if let DisplayEvent::WindowDestroy(WindowHandle(X11rbWindowHandle(w))) = event {
                 if let Err(e) = self.xw.force_unmapped(*w) {
                     tracing::error!(error = ?e, "Error when forcing unmapping of window {}", w);
                 };
@@ -95,17 +100,20 @@ impl DisplayServer for X11rbDisplayServer {
         events
     }
 
-    fn execute_action(&mut self, act: DisplayAction) -> Option<DisplayEvent> {
+    fn execute_action(
+        &mut self,
+        act: DisplayAction<X11rbWindowHandle>,
+    ) -> Option<DisplayEvent<X11rbWindowHandle>> {
         tracing::trace!("DisplayAction: {:?}", act);
         let xw = &mut self.xw;
-        let event: Result<Option<DisplayEvent>> = match act.clone() {
+        let event: Result<Option<DisplayEvent<X11rbWindowHandle>>> = match act.clone() {
             DisplayAction::KillWindow(h) => from_kill_window(xw, h),
             DisplayAction::AddedWindow(h, f, fm) => xw.setup_managed_window(h, f, fm),
             DisplayAction::MoveMouseOver(h, f) => from_move_mouse_over(xw, h, f),
             DisplayAction::MoveMouseOverPoint(p) => from_move_mouse_over_point(xw, p),
             DisplayAction::DestroyedWindow(h) => from_destroyed_window(xw, h),
             DisplayAction::Unfocus(h, f) => from_unfocus(xw, h, f),
-            DisplayAction::ReplayClick(h, b) => from_replay_click(xw, h, b.try_into().unwrap_or(0)),
+            DisplayAction::ReplayClick(h, b) => from_replay_click(xw, h, b.bits()),
             DisplayAction::SetState(h, t, s) => from_set_state(xw, h, t, s),
             DisplayAction::SetWindowOrder(ws) => from_set_window_order(xw, ws),
             DisplayAction::MoveToTop(h) => from_move_to_top(xw, h),
@@ -131,7 +139,11 @@ impl DisplayServer for X11rbDisplayServer {
                 ev
             }
             Err(e) => {
-                tracing::error!("Error when processing a display action:\n\tAction: {:?}\n\tError: {}", act, e);
+                tracing::error!(
+                    "Error when processing a display action:\n\tAction: {:?}\n\tError: {}",
+                    act,
+                    e
+                );
                 None
             }
         }
@@ -150,14 +162,14 @@ impl DisplayServer for X11rbDisplayServer {
         }
     }
 
-    fn generate_verify_focus_event(&self) -> Option<leftwm_core::DisplayEvent> {
+    fn generate_verify_focus_event(&self) -> Option<leftwm_core::DisplayEvent<X11rbWindowHandle>> {
         let handle = self.xw.get_cursor_window().ok()?;
         Some(DisplayEvent::VerifyFocusedAt(handle))
     }
 }
 
 impl X11rbDisplayServer {
-    fn initial_events(&self, config: &impl Config) -> Vec<DisplayEvent> {
+    fn initial_events(&self, config: &impl Config) -> Vec<DisplayEvent<X11rbWindowHandle>> {
         let mut events = vec![];
         if let Some(workspaces) = config.workspaces() {
             let screens = match self.xw.get_screens() {
@@ -170,7 +182,7 @@ impl X11rbDisplayServer {
 
             for (i, wsc) in workspaces.iter().enumerate() {
                 let mut screen = Screen::from(wsc);
-                screen.root = WindowHandle::X11rbHandle(self.root);
+                screen.root = WindowHandle(X11rbWindowHandle(self.root));
                 // If there is a screen corresponding to the given output, create the workspace
                 match screens.iter().find(|i| i.output == wsc.output) {
                     Some(output_match) => {
@@ -216,8 +228,8 @@ impl X11rbDisplayServer {
         events
     }
 
-    fn find_all_windows(&self) -> Vec<DisplayEvent> {
-        let mut all: Vec<DisplayEvent> = Vec::new();
+    fn find_all_windows(&self) -> Vec<DisplayEvent<X11rbWindowHandle>> {
+        let mut all: Vec<DisplayEvent<X11rbWindowHandle>> = Vec::new();
         match self.xw.get_all_windows() {
             Ok(handles) => handles.into_iter().for_each(|handle| {
                 let attrs = match self.xw.get_window_attrs(handle) {
@@ -253,18 +265,21 @@ impl X11rbDisplayServer {
 }
 
 // Display actions.
-fn from_kill_window(xw: &mut XWrap, handle: WindowHandle) -> Result<Option<DisplayEvent>> {
+fn from_kill_window(
+    xw: &mut XWrap,
+    handle: WindowHandle<X11rbWindowHandle>,
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     xw.kill_window(&handle)?;
     Ok(None)
 }
 
 fn from_move_mouse_over(
     xw: &mut XWrap,
-    handle: WindowHandle,
+    handle: WindowHandle<X11rbWindowHandle>,
     force: bool,
-) -> Result<Option<DisplayEvent>> {
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     match (handle, xw.get_cursor_window()?) {
-        (WindowHandle::X11rbHandle(window), WindowHandle::X11rbHandle(cursor_window))
+        (WindowHandle(X11rbWindowHandle(window)), WindowHandle(X11rbWindowHandle(cursor_window)))
             if force || cursor_window != window =>
         {
             _ = xw.move_cursor_to_window(window)?;
@@ -274,31 +289,37 @@ fn from_move_mouse_over(
     Ok(None)
 }
 
-fn from_move_mouse_over_point(xw: &mut XWrap, point: (i32, i32)) -> Result<Option<DisplayEvent>> {
+fn from_move_mouse_over_point(
+    xw: &mut XWrap,
+    point: (i32, i32),
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     xw.move_cursor_to_point(point)?;
     Ok(None)
 }
 
-fn from_destroyed_window(xw: &mut XWrap, handle: WindowHandle) -> Result<Option<DisplayEvent>> {
+fn from_destroyed_window(
+    xw: &mut XWrap,
+    handle: WindowHandle<X11rbWindowHandle>,
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     xw.teardown_managed_window(&handle, true)?;
     Ok(None)
 }
 
 fn from_unfocus(
     xw: &mut XWrap,
-    handle: Option<WindowHandle>,
+    handle: Option<WindowHandle<X11rbWindowHandle>>,
     floating: bool,
-) -> Result<Option<DisplayEvent>> {
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     xw.unfocus(handle, floating)?;
     Ok(None)
 }
 
 fn from_replay_click(
     xw: &mut XWrap,
-    handle: WindowHandle,
+    handle: WindowHandle<X11rbWindowHandle>,
     button: xproto::Button,
-) -> Result<Option<DisplayEvent>> {
-    if let WindowHandle::X11rbHandle(handle) = handle {
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
+    if let WindowHandle(X11rbWindowHandle(handle)) = handle {
         xw.replay_click(handle, button)?;
     }
     Ok(None)
@@ -306,10 +327,10 @@ fn from_replay_click(
 
 fn from_set_state(
     xw: &mut XWrap,
-    handle: WindowHandle,
+    handle: WindowHandle<X11rbWindowHandle>,
     toggle_to: bool,
     window_state: WindowState,
-) -> Result<Option<DisplayEvent>> {
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     // TODO: impl from for windowstate and xlib::Atom
     let state = match window_state {
         WindowState::Modal => xw.atoms.NetWMStateModal,
@@ -335,50 +356,59 @@ fn from_set_state(
 
 fn from_set_window_order(
     xw: &mut XWrap,
-    windows: Vec<WindowHandle>,
-) -> Result<Option<DisplayEvent>> {
+    windows: Vec<WindowHandle<X11rbWindowHandle>>,
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     // Unmanaged windows.
-    let unmanaged: Vec<WindowHandle> = xw
+    let unmanaged: Vec<WindowHandle<X11rbWindowHandle>> = xw
         .get_all_windows()?
         .iter()
         .filter(|&w| *w != xw.get_default_root())
-        .map(|&w| WindowHandle::X11rbHandle(w))
+        .map(|&w| WindowHandle(X11rbWindowHandle(w)))
         .filter(|h| !windows.iter().any(|&w| w == *h))
         .collect();
-    let all: Vec<WindowHandle> = [unmanaged, windows].concat();
+    let all: Vec<WindowHandle<X11rbWindowHandle>> = [unmanaged, windows].concat();
     xw.restack(all)?;
     Ok(None)
 }
 
-fn from_move_to_top(xw: &mut XWrap, handle: WindowHandle) -> Result<Option<DisplayEvent>> {
+fn from_move_to_top(
+    xw: &mut XWrap,
+    handle: WindowHandle<X11rbWindowHandle>,
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     xw.move_to_top(&handle)?;
     Ok(None)
 }
 
-fn from_ready_to_move_window(xw: &mut XWrap, handle: WindowHandle) -> Result<Option<DisplayEvent>> {
+fn from_ready_to_move_window(
+    xw: &mut XWrap,
+    handle: WindowHandle<X11rbWindowHandle>,
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     xw.set_mode(Mode::ReadyToMove(handle))?;
     Ok(None)
 }
 
 fn from_ready_to_resize_window(
     xw: &mut XWrap,
-    handle: WindowHandle,
-) -> Result<Option<DisplayEvent>> {
+    handle: WindowHandle<X11rbWindowHandle>,
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     xw.set_mode(Mode::ReadyToResize(handle))?;
     Ok(None)
 }
 
-fn from_set_current_tags(xw: &mut XWrap, tag: Option<TagId>) -> Result<Option<DisplayEvent>> {
+fn from_set_current_tags(
+    xw: &mut XWrap,
+    tag: Option<TagId>,
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     xw.set_current_desktop(tag)?;
     Ok(None)
 }
 
 fn from_set_window_tag(
     xw: &mut XWrap,
-    handle: WindowHandle,
+    handle: WindowHandle<X11rbWindowHandle>,
     tag: Option<TagId>,
-) -> Result<Option<DisplayEvent>> {
-    if let WindowHandle::X11rbHandle(window) = handle {
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
+    if let WindowHandle(X11rbWindowHandle(window)) = handle {
         match tag {
             Some(tag) => xw.set_window_desktop(window, &tag)?,
             None => (),
@@ -387,23 +417,28 @@ fn from_set_window_tag(
     Ok(None)
 }
 
-fn from_configure_xlib_window(xw: &mut XWrap, window: &Window) -> Result<Option<DisplayEvent>> {
+fn from_configure_xlib_window(
+    xw: &mut XWrap,
+    window: &Window<X11rbWindowHandle>,
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     xw.configure_window(window)?;
     Ok(None)
 }
 
 fn from_window_take_focus(
     xw: &mut XWrap,
-    window: &Window,
-    previous_window: &Option<Window>,
-) -> Result<Option<DisplayEvent>> {
+    window: &Window<X11rbWindowHandle>,
+    previous_window: &Option<Window<X11rbWindowHandle>>,
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     xw.window_take_focus(window, previous_window.as_ref())?;
     Ok(None)
 }
 
-fn from_focus_window_under_cursor(xw: &mut XWrap) -> Result<Option<DisplayEvent>> {
+fn from_focus_window_under_cursor(
+    xw: &mut XWrap,
+) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     let mut window = xw.get_cursor_window()?;
-    if window == WindowHandle::X11rbHandle(0) {
+    if window == WindowHandle(X11rbWindowHandle(0)) {
         window = xw.get_default_root_handle();
         return Ok(Some(DisplayEvent::WindowTakeFocus(window)));
     }
@@ -412,7 +447,7 @@ fn from_focus_window_under_cursor(xw: &mut XWrap) -> Result<Option<DisplayEvent>
     Ok(Some(evt))
 }
 
-fn from_normal_mode(xw: &mut XWrap) -> Result<Option<DisplayEvent>> {
+fn from_normal_mode(xw: &mut XWrap) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     xw.set_mode(Mode::Normal)?;
     Ok(None)
 }

--- a/display-servers/x11rb-display-server/src/xwrap/mouse.rs
+++ b/display-servers/x11rb-display-server/src/xwrap/mouse.rs
@@ -15,7 +15,7 @@ impl XWrap {
             self.grab_buttons(handle, xproto::ButtonIndex::M1, xproto::ModMask::ANY)?;
             self.grab_buttons(handle, xproto::ButtonIndex::M3, xproto::ModMask::ANY)?;
         }
-        let mouse_key_mask = xproto::ModMask::from(self.mouse_key_mask as u16);
+        let mouse_key_mask = xproto::ModMask::from(self.mouse_key_mask.bits() as u16);
         self.grab_buttons(handle, xproto::ButtonIndex::M1, mouse_key_mask)?;
         self.grab_buttons(
             handle,

--- a/display-servers/x11rb-display-server/src/xwrap/setters.rs
+++ b/display-servers/x11rb-display-server/src/xwrap/setters.rs
@@ -6,7 +6,7 @@ use x11rb::{
     protocol::xproto::{self, ChangeWindowAttributesAux, PropMode},
 };
 
-use crate::{error::Result, xatom};
+use crate::{error::Result, xatom, X11rbWindowHandle};
 
 use super::XWrap;
 
@@ -129,11 +129,11 @@ impl XWrap {
     /// Sets a windows state.
     pub fn set_state(
         &self,
-        handle: WindowHandle,
+        handle: WindowHandle<X11rbWindowHandle>,
         toggle_to: bool,
         atom: xproto::Atom,
     ) -> Result<()> {
-        if let WindowHandle::X11rbHandle(h) = handle {
+        if let WindowHandle(X11rbWindowHandle(h)) = handle {
             let mut states = self.get_window_states_atoms(h)?;
             if toggle_to {
                 if states.contains(&atom) {

--- a/display-servers/xlib-display-server/Cargo.toml
+++ b/display-servers/xlib-display-server/Cargo.toml
@@ -14,3 +14,4 @@ futures = "0.3.21"
 tracing = "0.1.36"
 tokio = { version = "1.2.0", features = [ "sync", "time" ] }
 mio = { version = "0.8.0", features = ["os-ext"] }
+serde = { version = "1.0.104", features = ["derive"] }

--- a/display-servers/xlib-display-server/src/lib.rs
+++ b/display-servers/xlib-display-server/src/lib.rs
@@ -11,13 +11,16 @@ mod xatom;
 mod xcursor;
 mod xwrap;
 
+use serde::{Serialize, Deserialize};
 pub use xwrap::XWrap;
 
 use self::xwrap::ICONIC_STATE;
 use event_translate::XEvent;
 use futures::prelude::*;
 use leftwm_core::config::Config;
-use leftwm_core::models::{Mode, Screen, TagId, Window, WindowHandle, WindowState, Workspace};
+use leftwm_core::models::{
+    Handle, Mode, Screen, TagId, Window, WindowHandle, WindowState, Workspace,
+};
 use leftwm_core::utils;
 use leftwm_core::{DisplayAction, DisplayEvent, DisplayServer};
 use std::os::raw::c_uint;
@@ -25,13 +28,17 @@ use std::pin::Pin;
 
 use x11_dl::xlib;
 
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct XlibWindowHandle(xlib::Window);
+impl Handle for XlibWindowHandle {}
+
 pub struct XlibDisplayServer {
     xw: XWrap,
     root: xlib::Window,
-    initial_events: Vec<DisplayEvent>,
+    initial_events: Vec<DisplayEvent<XlibWindowHandle>>,
 }
 
-impl DisplayServer for XlibDisplayServer {
+impl DisplayServer<XlibWindowHandle> for XlibDisplayServer {
     fn new(config: &impl Config) -> Self {
         let mut wrap = XWrap::new();
 
@@ -54,13 +61,13 @@ impl DisplayServer for XlibDisplayServer {
     fn load_config(
         &mut self,
         config: &impl Config,
-        focused: Option<&Option<WindowHandle>>,
-        windows: &[Window],
+        focused: Option<&Option<WindowHandle<XlibWindowHandle>>>,
+        windows: &[Window<XlibWindowHandle>],
     ) {
         self.xw.load_config(config, focused, windows);
     }
 
-    fn update_windows(&self, windows: Vec<&Window>) {
+    fn update_windows(&self, windows: Vec<&Window<XlibWindowHandle>>) {
         for window in &windows {
             self.xw.update_window(window);
         }
@@ -72,7 +79,7 @@ impl DisplayServer for XlibDisplayServer {
         }
     }
 
-    fn get_next_events(&mut self) -> Vec<DisplayEvent> {
+    fn get_next_events(&mut self) -> Vec<DisplayEvent<XlibWindowHandle>> {
         let mut events = std::mem::take(&mut self.initial_events);
 
         let events_in_queue = self.xw.queue_len();
@@ -86,7 +93,7 @@ impl DisplayServer for XlibDisplayServer {
         }
 
         for event in &events {
-            if let DisplayEvent::WindowDestroy(WindowHandle::XlibHandle(w)) = event {
+            if let DisplayEvent::WindowDestroy(WindowHandle(XlibWindowHandle(w))) = event {
                 self.xw.force_unmapped(*w);
             }
         }
@@ -94,17 +101,20 @@ impl DisplayServer for XlibDisplayServer {
         events
     }
 
-    fn execute_action(&mut self, act: DisplayAction) -> Option<DisplayEvent> {
+    fn execute_action(
+        &mut self,
+        act: DisplayAction<XlibWindowHandle>,
+    ) -> Option<DisplayEvent<XlibWindowHandle>> {
         tracing::trace!("DisplayAction: {:?}", act);
         let xw = &mut self.xw;
-        let event: Option<DisplayEvent> = match act {
+        let event: Option<DisplayEvent<XlibWindowHandle>> = match act {
             DisplayAction::KillWindow(h) => from_kill_window(xw, h),
             DisplayAction::AddedWindow(h, f, fm) => from_added_window(xw, h, f, fm),
             DisplayAction::MoveMouseOver(h, f) => from_move_mouse_over(xw, h, f),
             DisplayAction::MoveMouseOverPoint(p) => from_move_mouse_over_point(xw, p),
             DisplayAction::DestroyedWindow(h) => from_destroyed_window(xw, h),
             DisplayAction::Unfocus(h, f) => from_unfocus(xw, h, f),
-            DisplayAction::ReplayClick(h, b) => from_replay_click(xw, h, b),
+            DisplayAction::ReplayClick(h, b) => from_replay_click(xw, h, b.bits().into()),
             DisplayAction::SetState(h, t, s) => from_set_state(xw, h, t, s),
             DisplayAction::SetWindowOrder(ws) => from_set_window_order(xw, ws),
             DisplayAction::MoveToTop(h) => from_move_to_top(xw, h),
@@ -140,7 +150,7 @@ impl DisplayServer for XlibDisplayServer {
     }
 
     /// Creates a verify focus event for the cursors current window.
-    fn generate_verify_focus_event(&self) -> Option<DisplayEvent> {
+    fn generate_verify_focus_event(&self) -> Option<DisplayEvent<XlibWindowHandle>> {
         let handle = self.xw.get_cursor_window().ok()?;
         Some(DisplayEvent::VerifyFocusedAt(handle))
     }
@@ -148,13 +158,13 @@ impl DisplayServer for XlibDisplayServer {
 
 impl XlibDisplayServer {
     /// Return a vec of events for setting up state of WM.
-    fn initial_events(&self, config: &impl Config) -> Vec<DisplayEvent> {
+    fn initial_events(&self, config: &impl Config) -> Vec<DisplayEvent<XlibWindowHandle>> {
         let mut events = vec![];
         if let Some(workspaces) = config.workspaces() {
             let screens = self.xw.get_screens();
             for (i, wsc) in workspaces.iter().enumerate() {
                 let mut screen = Screen::from(wsc);
-                screen.root = self.root.into();
+                screen.root = WindowHandle(XlibWindowHandle(self.root));
                 // If there is a screen corresponding to the given output, create the workspace
                 match screens.iter().find(|i| i.output == wsc.output) {
                     Some(output_match) => {
@@ -200,8 +210,8 @@ impl XlibDisplayServer {
         events
     }
 
-    fn find_all_windows(&self) -> Vec<DisplayEvent> {
-        let mut all: Vec<DisplayEvent> = Vec::new();
+    fn find_all_windows(&self) -> Vec<DisplayEvent<XlibWindowHandle>> {
+        let mut all: Vec<DisplayEvent<XlibWindowHandle>> = Vec::new();
         match self.xw.get_all_windows() {
             Ok(handles) => handles.into_iter().for_each(|handle| {
                 let Ok(attrs) = self.xw.get_window_attrs(handle) else {
@@ -225,24 +235,31 @@ impl XlibDisplayServer {
 }
 
 // Display actions.
-fn from_kill_window(xw: &mut XWrap, handle: WindowHandle) -> Option<DisplayEvent> {
+fn from_kill_window(
+    xw: &mut XWrap,
+    handle: WindowHandle<XlibWindowHandle>,
+) -> Option<DisplayEvent<XlibWindowHandle>> {
     xw.kill_window(&handle);
     None
 }
 
 fn from_added_window(
     xw: &mut XWrap,
-    handle: WindowHandle,
+    handle: WindowHandle<XlibWindowHandle>,
     floating: bool,
     follow_mouse: bool,
-) -> Option<DisplayEvent> {
+) -> Option<DisplayEvent<XlibWindowHandle>> {
     xw.setup_managed_window(handle, floating, follow_mouse)
 }
 
-fn from_move_mouse_over(xw: &mut XWrap, handle: WindowHandle, force: bool) -> Option<DisplayEvent> {
-    let window = handle.xlib_handle()?;
+fn from_move_mouse_over(
+    xw: &mut XWrap,
+    handle: WindowHandle<XlibWindowHandle>,
+    force: bool,
+) -> Option<DisplayEvent<XlibWindowHandle>> {
+    let WindowHandle(XlibWindowHandle(window)) = handle;
     match xw.get_cursor_window() {
-        Ok(WindowHandle::XlibHandle(cursor_window)) if force || cursor_window != window => {
+        Ok(WindowHandle(XlibWindowHandle(cursor_window))) if force || cursor_window != window => {
             _ = xw.move_cursor_to_window(window);
         }
         _ => {}
@@ -250,27 +267,37 @@ fn from_move_mouse_over(xw: &mut XWrap, handle: WindowHandle, force: bool) -> Op
     None
 }
 
-fn from_move_mouse_over_point(xw: &mut XWrap, point: (i32, i32)) -> Option<DisplayEvent> {
+fn from_move_mouse_over_point(
+    xw: &mut XWrap,
+    point: (i32, i32),
+) -> Option<DisplayEvent<XlibWindowHandle>> {
     _ = xw.move_cursor_to_point(point);
     None
 }
 
-fn from_destroyed_window(xw: &mut XWrap, handle: WindowHandle) -> Option<DisplayEvent> {
+fn from_destroyed_window(
+    xw: &mut XWrap,
+    handle: WindowHandle<XlibWindowHandle>,
+) -> Option<DisplayEvent<XlibWindowHandle>> {
     xw.teardown_managed_window(&handle, true);
     None
 }
 
 fn from_unfocus(
     xw: &mut XWrap,
-    handle: Option<WindowHandle>,
+    handle: Option<WindowHandle<XlibWindowHandle>>,
     floating: bool,
-) -> Option<DisplayEvent> {
+) -> Option<DisplayEvent<XlibWindowHandle>> {
     xw.unfocus(handle, floating);
     None
 }
 
-fn from_replay_click(xw: &mut XWrap, handle: WindowHandle, button: c_uint) -> Option<DisplayEvent> {
-    if let WindowHandle::XlibHandle(handle) = handle {
+fn from_replay_click(
+    xw: &mut XWrap,
+    handle: WindowHandle<XlibWindowHandle>,
+    button: c_uint,
+) -> Option<DisplayEvent<XlibWindowHandle>> {
+    if let WindowHandle(XlibWindowHandle(handle)) = handle {
         xw.replay_click(handle, button);
     }
     None
@@ -278,10 +305,10 @@ fn from_replay_click(xw: &mut XWrap, handle: WindowHandle, button: c_uint) -> Op
 
 fn from_set_state(
     xw: &mut XWrap,
-    handle: WindowHandle,
+    handle: WindowHandle<XlibWindowHandle>,
     toggle_to: bool,
     window_state: WindowState,
-) -> Option<DisplayEvent> {
+) -> Option<DisplayEvent<XlibWindowHandle>> {
     // TODO: impl from for windowstate and xlib::Atom
     let state = match window_state {
         WindowState::Modal => xw.atoms.NetWMStateModal,
@@ -305,14 +332,17 @@ fn from_set_state(
     None
 }
 
-fn from_set_window_order(xw: &mut XWrap, windows: Vec<WindowHandle>) -> Option<DisplayEvent> {
+fn from_set_window_order(
+    xw: &mut XWrap,
+    windows: Vec<WindowHandle<XlibWindowHandle>>,
+) -> Option<DisplayEvent<XlibWindowHandle>> {
     // Unmanaged windows.
-    let unmanaged: Vec<WindowHandle> = xw
+    let unmanaged: Vec<WindowHandle<XlibWindowHandle>> = xw
         .get_all_windows()
         .unwrap_or_default()
         .iter()
         .filter(|&w| *w != xw.get_default_root())
-        .map(|&w| w.into())
+        .map(|&w| WindowHandle(XlibWindowHandle(w)))
         .filter(|h| !windows.iter().any(|w| w == h))
         .collect();
     // Unmanaged windows on top.
@@ -320,54 +350,69 @@ fn from_set_window_order(xw: &mut XWrap, windows: Vec<WindowHandle>) -> Option<D
     None
 }
 
-fn from_move_to_top(xw: &mut XWrap, handle: WindowHandle) -> Option<DisplayEvent> {
+fn from_move_to_top(
+    xw: &mut XWrap,
+    handle: WindowHandle<XlibWindowHandle>,
+) -> Option<DisplayEvent<XlibWindowHandle>> {
     xw.move_to_top(&handle);
     None
 }
 
-fn from_ready_to_move_window(xw: &mut XWrap, handle: WindowHandle) -> Option<DisplayEvent> {
+fn from_ready_to_move_window(
+    xw: &mut XWrap,
+    handle: WindowHandle<XlibWindowHandle>,
+) -> Option<DisplayEvent<XlibWindowHandle>> {
     xw.set_mode(Mode::ReadyToMove(handle));
     None
 }
 
-fn from_ready_to_resize_window(xw: &mut XWrap, handle: WindowHandle) -> Option<DisplayEvent> {
+fn from_ready_to_resize_window(
+    xw: &mut XWrap,
+    handle: WindowHandle<XlibWindowHandle>,
+) -> Option<DisplayEvent<XlibWindowHandle>> {
     xw.set_mode(Mode::ReadyToResize(handle));
     None
 }
 
-fn from_set_current_tags(xw: &mut XWrap, tag: Option<TagId>) -> Option<DisplayEvent> {
+fn from_set_current_tags(
+    xw: &mut XWrap,
+    tag: Option<TagId>,
+) -> Option<DisplayEvent<XlibWindowHandle>> {
     xw.set_current_desktop(tag);
     None
 }
 
 fn from_set_window_tag(
     xw: &mut XWrap,
-    handle: WindowHandle,
+    handle: WindowHandle<XlibWindowHandle>,
     tag: Option<TagId>,
-) -> Option<DisplayEvent> {
-    let window = handle.xlib_handle()?;
+) -> Option<DisplayEvent<XlibWindowHandle>> {
+    let WindowHandle(XlibWindowHandle(window)) = handle;
     let tag = tag?;
     xw.set_window_desktop(window, &tag);
     None
 }
 
-fn from_configure_xlib_window(xw: &mut XWrap, window: &Window) -> Option<DisplayEvent> {
+fn from_configure_xlib_window(
+    xw: &mut XWrap,
+    window: &Window<XlibWindowHandle>,
+) -> Option<DisplayEvent<XlibWindowHandle>> {
     xw.configure_window(window);
     None
 }
 
 fn from_window_take_focus(
     xw: &mut XWrap,
-    window: &Window,
-    previous_window: &Option<Window>,
-) -> Option<DisplayEvent> {
+    window: &Window<XlibWindowHandle>,
+    previous_window: &Option<Window<XlibWindowHandle>>,
+) -> Option<DisplayEvent<XlibWindowHandle>> {
     xw.window_take_focus(window, previous_window.as_ref());
     None
 }
 
-fn from_focus_window_under_cursor(xw: &mut XWrap) -> Option<DisplayEvent> {
+fn from_focus_window_under_cursor(xw: &mut XWrap) -> Option<DisplayEvent<XlibWindowHandle>> {
     if let Ok(mut window) = xw.get_cursor_window() {
-        if window == WindowHandle::XlibHandle(0) {
+        if window == WindowHandle(XlibWindowHandle(0)) {
             window = xw.get_default_root_handle();
         }
         return Some(DisplayEvent::WindowTakeFocus(window));
@@ -377,7 +422,7 @@ fn from_focus_window_under_cursor(xw: &mut XWrap) -> Option<DisplayEvent> {
     Some(evt)
 }
 
-fn from_normal_mode(xw: &mut XWrap) -> Option<DisplayEvent> {
+fn from_normal_mode(xw: &mut XWrap) -> Option<DisplayEvent<XlibWindowHandle>> {
     xw.set_mode(Mode::Normal);
     None
 }

--- a/display-servers/xlib-display-server/src/xwrap/mouse.rs
+++ b/display-servers/xlib-display-server/src/xwrap/mouse.rs
@@ -13,10 +13,18 @@ impl XWrap {
             self.grab_buttons(handle, xlib::Button1, xlib::AnyModifier);
             self.grab_buttons(handle, xlib::Button3, xlib::AnyModifier);
         }
-        self.grab_buttons(handle, xlib::Button1, self.mouse_key_mask);
-        self.grab_buttons(handle, xlib::Button1, self.mouse_key_mask | xlib::ShiftMask);
-        self.grab_buttons(handle, xlib::Button3, self.mouse_key_mask);
-        self.grab_buttons(handle, xlib::Button3, self.mouse_key_mask | xlib::ShiftMask);
+        self.grab_buttons(handle, xlib::Button1, self.mouse_key_mask.bits() as u32);
+        self.grab_buttons(
+            handle,
+            xlib::Button1,
+            self.mouse_key_mask.bits() as u32 | xlib::ShiftMask,
+        );
+        self.grab_buttons(handle, xlib::Button3, self.mouse_key_mask.bits() as u32);
+        self.grab_buttons(
+            handle,
+            xlib::Button3,
+            self.mouse_key_mask.bits() as u32 | xlib::ShiftMask,
+        );
     }
 
     /// Grabs the button with the modifier for a window.

--- a/display-servers/xlib-display-server/src/xwrap/setters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/setters.rs
@@ -1,6 +1,6 @@
 //! `XWrap` setters.
 use super::WindowHandle;
-use crate::XWrap;
+use crate::{XWrap, XlibWindowHandle};
 use leftwm_core::models::TagId;
 use std::ffi::CString;
 use std::os::raw::{c_long, c_ulong};
@@ -129,8 +129,13 @@ impl XWrap {
     }
 
     /// Sets a windows state.
-    pub fn set_state(&self, handle: WindowHandle, toggle_to: bool, atom: xlib::Atom) {
-        if let WindowHandle::XlibHandle(h) = handle {
+    pub fn set_state(
+        &self,
+        handle: WindowHandle<XlibWindowHandle>,
+        toggle_to: bool,
+        atom: xlib::Atom,
+    ) {
+        if let WindowHandle(XlibWindowHandle(h)) = handle {
             let mut states = self.get_window_states_atoms(h);
             if toggle_to {
                 if states.contains(&atom) {

--- a/leftwm-core/Cargo.toml
+++ b/leftwm-core/Cargo.toml
@@ -31,9 +31,8 @@ tokio = { version = "1.2.0", features = [
   "time",
 ] }
 leftwm-layouts = "0.8.4"
-x11-dl = "2.18.4"
-x11rb = { version = "0.12.0", features = ["cursor", "randr", "xinerama"] }
 xdg = "2.2.0"
+bitflags = "2.4.2"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/leftwm-core/src/command.rs
+++ b/leftwm-core/src/command.rs
@@ -1,19 +1,21 @@
 pub use crate::handlers::command_handler::ReleaseScratchPadOption;
-use crate::models::{ScratchPadName, TagId, WindowHandle};
+use crate::models::{Handle, ScratchPadName, TagId, WindowHandle};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
-pub enum Command {
+pub enum Command<H: Handle> {
     CloseWindow,
     SwapScreens,
     SoftReload,
     HardReload,
     AttachScratchPad {
-        window: Option<WindowHandle>,
+        #[serde(bound = "")]
+        window: Option<WindowHandle<H>>,
         scratchpad: ScratchPadName,
     },
     ReleaseScratchPad {
-        window: ReleaseScratchPadOption,
+        #[serde(bound = "")]
+        window: ReleaseScratchPadOption<H>,
         tag: Option<TagId>,
     },
     PrevScratchPadWindow {
@@ -58,7 +60,8 @@ pub enum Command {
     FocusWorkspaceNext,
     FocusWorkspacePrevious,
     SendWindowToTag {
-        window: Option<WindowHandle>,
+        #[serde(bound = "")]
+        window: Option<WindowHandle<H>>,
         tag: TagId,
     },
     MoveWindowToNextTag {

--- a/leftwm-core/src/config.rs
+++ b/leftwm-core/src/config.rs
@@ -5,7 +5,7 @@ use crate::display_servers::DisplayServer;
 use crate::layouts::LayoutMode;
 pub use crate::models::ScratchPad;
 pub use crate::models::{FocusBehaviour, Gutter, Margins, Size};
-use crate::models::{Manager, Window, WindowType};
+use crate::models::{Manager, Window, WindowType, Handle};
 use crate::state::State;
 pub use insert_behavior::InsertBehavior;
 use leftwm_layouts::Layout;
@@ -34,9 +34,9 @@ pub trait Config {
 
     fn focus_new_windows(&self) -> bool;
 
-    fn command_handler<SERVER>(command: &str, manager: &mut Manager<Self, SERVER>) -> bool
+    fn command_handler<H: Handle, SERVER>(command: &str, manager: &mut Manager<H, Self, SERVER>) -> bool
     where
-        SERVER: DisplayServer,
+        SERVER: DisplayServer<H>,
         Self: Sized;
 
     fn always_float(&self) -> bool;
@@ -64,15 +64,15 @@ pub trait Config {
     /// It will be used to restore the state after soft reload.
     ///
     /// **Note:** this function cannot fail.
-    fn save_state(&self, state: &State);
+    fn save_state<H: Handle>(&self, state: &State<H>);
 
     /// Load saved state if it exists.
-    fn load_state(&self, state: &mut State);
+    fn load_state<H: Handle>(&self, state: &mut State<H>);
 
     /// Handle window placement based on `WM_CLASS`
-    fn setup_predefined_window(&self, state: &mut State, window: &mut Window) -> bool;
+    fn setup_predefined_window<H: Handle>(&self, state: &mut State<H>, window: &mut Window<H>) -> bool;
 
-    fn load_window(&self, window: &mut Window) {
+    fn load_window<H: Handle>(&self, window: &mut Window<H>) {
         if window.r#type == WindowType::Normal {
             window.margin = self.margin();
             window.border = self.border_width();
@@ -87,6 +87,7 @@ pub trait Config {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+    use crate::models::MockHandle;
     use crate::models::Screen;
     use crate::models::Window;
     use crate::models::WindowHandle;
@@ -140,9 +141,9 @@ pub(crate) mod tests {
         fn focus_new_windows(&self) -> bool {
             false
         }
-        fn command_handler<SERVER>(command: &str, manager: &mut Manager<Self, SERVER>) -> bool
+        fn command_handler<H: Handle, SERVER>(command: &str, manager: &mut Manager<H, Self, SERVER>) -> bool
         where
-            SERVER: DisplayServer,
+            SERVER: DisplayServer<H>,
         {
             match command {
                 "GoToTag2" => manager.command_handler(&crate::Command::GoToTag {
@@ -197,13 +198,13 @@ pub(crate) mod tests {
         fn disable_window_snap(&self) -> bool {
             false
         }
-        fn save_state(&self, _state: &State) {
+        fn save_state<H: Handle>(&self, _state: &State<H>) {
             unimplemented!()
         }
-        fn load_state(&self, _state: &mut State) {
+        fn load_state<H: Handle>(&self, _state: &mut State<H>) {
             unimplemented!()
         }
-        fn setup_predefined_window(&self, _: &mut State, window: &mut Window) -> bool {
+        fn setup_predefined_window<H: Handle>(&self, _: &mut State<H>, window: &mut Window<H>) -> bool {
             if window.res_class == Some("ShouldGoToTag2".to_string()) {
                 window.tag = Some(2);
                 true
@@ -240,7 +241,7 @@ pub(crate) mod tests {
     fn check_wm_class_is_associated_with_predefined_tag() {
         let mut manager = Manager::new_test(vec!["1".to_string(), "2".to_string()]);
         manager.screen_create_handler(Screen::default());
-        let mut subject = Window::new(WindowHandle::MockHandle(1), None, None);
+        let mut subject = Window::new(WindowHandle::<MockHandle>(1), None, None);
         subject.res_class = Some("ShouldGoToTag2".to_string());
         manager.window_created_handler(subject, 0, 0);
         assert!(manager.state.windows.iter().all(|w| w.has_tag(&2)));

--- a/leftwm-core/src/display_action.rs
+++ b/leftwm-core/src/display_action.rs
@@ -1,3 +1,4 @@
+use crate::models::Handle;
 use crate::models::TagId;
 use crate::models::Window;
 use crate::models::WindowHandle;
@@ -9,64 +10,78 @@ use serde::{Deserialize, Serialize};
 /// The display server should act on these actions.
 #[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub enum DisplayAction {
+pub enum DisplayAction<H: Handle> {
     /// Nicely ask a window if it would please close at its convenience.
-    KillWindow(WindowHandle),
+    #[serde(bound = "")]
+    KillWindow(WindowHandle<H>),
 
     /// Get triggered after a new window is discovered and WE are
     /// managing it.
-    AddedWindow(WindowHandle, bool, bool),
+    #[serde(bound = "")]
+    AddedWindow(WindowHandle<H>, bool, bool),
 
     /// Makes sure the mouse is over a given window.
-    MoveMouseOver(WindowHandle, bool),
+    #[serde(bound = "")]
+    MoveMouseOver(WindowHandle<H>, bool),
 
     /// Makes sure the mouse is over a given point.
     MoveMouseOverPoint((i32, i32)),
 
     /// Change a windows state.
-    SetState(WindowHandle, bool, WindowState),
+    #[serde(bound = "")]
+    SetState(WindowHandle<H>, bool, WindowState),
 
     /// Sets the "z-index" order of the windows
     /// first in the array is top most
-    SetWindowOrder(Vec<WindowHandle>),
+    #[serde(bound = "")]
+    SetWindowOrder(Vec<WindowHandle<H>>),
 
     /// Raises a given window.
-    MoveToTop(WindowHandle),
+    #[serde(bound = "")]
+    MoveToTop(WindowHandle<H>),
 
     /// Tell the DS we no longer care about the this window and other
     /// cleanup.
-    DestroyedWindow(WindowHandle),
+    #[serde(bound = "")]
+    DestroyedWindow(WindowHandle<H>),
 
     /// Tell a window that it is to become focused.
+    #[serde(bound = "")]
     WindowTakeFocus {
-        window: Window,
-        previous_window: Option<Window>,
+        window: Window<H>,
+        previous_window: Option<Window<H>>,
     },
 
     /// Remove focus on any visible window by focusing the root window.
-    Unfocus(Option<WindowHandle>, bool),
+    #[serde(bound = "")]
+    Unfocus(Option<WindowHandle<H>>, bool),
 
     /// To the window under the cursor to take the focus.
     FocusWindowUnderCursor,
 
-    ReplayClick(WindowHandle, Button),
+    #[serde(bound = "")]
+    ReplayClick(WindowHandle<H>, Button),
 
     /// Tell the DM we are ready to resize this window.
-    ReadyToResizeWindow(WindowHandle),
+    #[serde(bound = "")]
+    ReadyToResizeWindow(WindowHandle<H>),
 
     /// Tell the DM we are ready to move this window.
-    ReadyToMoveWindow(WindowHandle),
+    #[serde(bound = "")]
+    ReadyToMoveWindow(WindowHandle<H>),
 
     /// Used to let the WM know of the current displayed tag changes.
     SetCurrentTags(Option<TagId>),
 
     /// Used to let the WM know of the tag for a given window.
-    SetWindowTag(WindowHandle, Option<TagId>),
+    #[serde(bound = "")]
+    SetWindowTag(WindowHandle<H>, Option<TagId>),
 
     /// Tell the DM to return to normal mode if it is not (ie resize a
     /// window or moving a window).
     NormalMode,
 
     /// Configure a xlib window.
-    ConfigureXlibWindow(Window),
+    #[serde(bound = "")]
+    ConfigureXlibWindow(Window<H>),
 }

--- a/leftwm-core/src/display_event.rs
+++ b/leftwm-core/src/display_event.rs
@@ -1,23 +1,23 @@
 use super::{models::Screen, models::Window, models::WindowHandle, Button, ModMask};
-use crate::models::WindowChange;
+use crate::models::{WindowChange, Handle};
 use crate::Command;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
-pub enum DisplayEvent {
-    Movement(WindowHandle, i32, i32),
-    MouseCombo(ModMask, Button, WindowHandle, i32, i32),
-    WindowCreate(Window, i32, i32),
-    WindowChange(WindowChange),
-    WindowDestroy(WindowHandle),
-    WindowTakeFocus(WindowHandle),
-    HandleWindowFocus(WindowHandle),
-    VerifyFocusedAt(WindowHandle), // Request focus validation for this window.
+pub enum DisplayEvent<H: Handle> {
+    Movement(WindowHandle<H>, i32, i32),
+    MouseCombo(ModMask, Button, WindowHandle<H>, i32, i32),
+    WindowCreate(Window<H>, i32, i32),
+    WindowChange(WindowChange<H>),
+    WindowDestroy(WindowHandle<H>),
+    WindowTakeFocus(WindowHandle<H>),
+    HandleWindowFocus(WindowHandle<H>),
+    VerifyFocusedAt(WindowHandle<H>), // Request focus validation for this window.
     MoveFocusTo(i32, i32),         // Focus the nearest window to this point.
-    MoveWindow(WindowHandle, i32, i32),
-    ResizeWindow(WindowHandle, i32, i32),
-    ScreenCreate(Screen),
-    SendCommand(Command),
-    ConfigureXlibWindow(WindowHandle), // TODO: check if this has backend specific code
+    MoveWindow(WindowHandle<H>, i32, i32),
+    ResizeWindow(WindowHandle<H>, i32, i32),
+    ScreenCreate(Screen<H>),
+    SendCommand(Command<H>),
+    ConfigureXlibWindow(WindowHandle<H>), // TODO: check if this has backend specific code
     ChangeToNormalMode,
 }

--- a/leftwm-core/src/display_servers.rs
+++ b/leftwm-core/src/display_servers.rs
@@ -3,6 +3,7 @@ mod mock_display_server;
 
 use crate::config::Config;
 use crate::display_action::DisplayAction;
+use crate::models::Handle;
 use crate::models::Window;
 use crate::models::WindowHandle;
 use crate::models::Workspace;
@@ -14,24 +15,24 @@ use std::pin::Pin;
 #[cfg(test)]
 pub use self::mock_display_server::MockDisplayServer;
 
-pub trait DisplayServer {
+pub trait DisplayServer<H: Handle> {
     fn new(config: &impl Config) -> Self;
 
-    fn get_next_events(&mut self) -> Vec<DisplayEvent>;
+    fn get_next_events(&mut self) -> Vec<DisplayEvent<H>>;
 
     fn load_config(
         &mut self,
         _config: &impl Config,
-        _focused: Option<&Option<WindowHandle>>,
-        _windows: &[Window],
+        _focused: Option<&Option<WindowHandle<H>>>,
+        _windows: &[Window<H>],
     ) {
     }
 
-    fn update_windows(&self, _windows: Vec<&Window>) {}
+    fn update_windows(&self, _windows: Vec<&Window<H>>) {}
 
     fn update_workspaces(&self, _focused: Option<&Workspace>) {}
 
-    fn execute_action(&mut self, _act: DisplayAction) -> Option<DisplayEvent> {
+    fn execute_action(&mut self, _act: DisplayAction<H>) -> Option<DisplayEvent<H>> {
         None
     }
 
@@ -39,5 +40,5 @@ pub trait DisplayServer {
 
     fn flush(&self);
 
-    fn generate_verify_focus_event(&self) -> Option<DisplayEvent>;
+    fn generate_verify_focus_event(&self) -> Option<DisplayEvent<H>>;
 }

--- a/leftwm-core/src/display_servers/mock_display_server.rs
+++ b/leftwm-core/src/display_servers/mock_display_server.rs
@@ -1,20 +1,21 @@
 use super::Config;
 use super::DisplayEvent;
 use super::DisplayServer;
+use crate::models::Handle;
 use crate::models::Screen;
 
 #[derive(Clone)]
-pub struct MockDisplayServer {
-    pub screens: Vec<Screen>,
+pub struct MockDisplayServer<H: Handle> {
+    pub screens: Vec<Screen<H>>,
 }
 
-impl DisplayServer for MockDisplayServer {
+impl<H: Handle> DisplayServer<H> for MockDisplayServer<H> {
     fn new(_: &impl Config) -> Self {
         Self { screens: vec![] }
     }
 
     // testing a couple mock event
-    fn get_next_events(&mut self) -> Vec<DisplayEvent> {
+    fn get_next_events(&mut self) -> Vec<DisplayEvent<H>> {
         vec![]
     }
 
@@ -26,7 +27,7 @@ impl DisplayServer for MockDisplayServer {
         unimplemented!()
     }
 
-    fn generate_verify_focus_event(&self) -> Option<DisplayEvent> {
+    fn generate_verify_focus_event(&self) -> Option<DisplayEvent<H>> {
         unimplemented!()
     }
 }

--- a/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
+++ b/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
@@ -9,15 +9,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     child_process::{exec_shell, ChildID},
-    models::{ScratchPadName, TagId, WindowHandle},
+    models::{Handle, ScratchPadName, TagId, WindowHandle},
     Command, Config, DisplayAction, DisplayServer, Manager, Window,
 };
 
 /// Describes the options for the release scratchpad command
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
-pub enum ReleaseScratchPadOption {
+pub enum ReleaseScratchPadOption<H: Handle> {
     /// Release a window from a scratchpad given a window handle
-    Handle(WindowHandle),
+    #[serde(bound = "")]
+    Handle(WindowHandle<H>),
     /// Release a window from a scratchpad given a scratchpad name, the most upper window in the
     /// scratchpad queue will be released
     ScratchpadName(ScratchPadName),
@@ -27,9 +28,9 @@ pub enum ReleaseScratchPadOption {
 
 /// Hide scratchpad window:
 /// Expects that the window handle is a valid handle to a visible scratchpad window
-fn hide_scratchpad<C: Config, SERVER: DisplayServer>(
-    manager: &mut Manager<C, SERVER>,
-    scratchpad_window: &WindowHandle,
+fn hide_scratchpad<H: Handle, C: Config, SERVER: DisplayServer<H>>(
+    manager: &mut Manager<H, C, SERVER>,
+    scratchpad_window: &WindowHandle<H>,
 ) -> Result<(), &'static str> {
     tracing::trace!("Hide scratchpad window {:?}", scratchpad_window);
     let nsp_tag = manager
@@ -99,9 +100,9 @@ fn hide_scratchpad<C: Config, SERVER: DisplayServer>(
 
 /// Makes a scratchpad window visible:
 /// Expects that the window handle is a valid handle to an invisible scratchpad window
-fn show_scratchpad<C: Config, SERVER: DisplayServer>(
-    manager: &mut Manager<C, SERVER>,
-    scratchpad_window: &WindowHandle,
+fn show_scratchpad<H: Handle, C: Config, SERVER: DisplayServer<H>>(
+    manager: &mut Manager<H, C, SERVER>,
+    scratchpad_window: &WindowHandle<H>,
 ) -> Result<(), &'static str> {
     tracing::trace!("Show scratchpad window {:?}", scratchpad_window);
     let current_tag = &manager
@@ -147,9 +148,9 @@ fn show_scratchpad<C: Config, SERVER: DisplayServer>(
 /// With the introduction of `VecDeque` for scratchpads, it is possible that a window gets destroyed
 /// in the middle of the `VecDeque`. This is an abstraction to retrieve the next valid pid from a
 /// scratchpad. While walking the scratchpad windows, invalid pids will get removed.
-fn next_valid_scratchpad_pid(
+fn next_valid_scratchpad_pid<H: Handle>(
     scratchpad_windows: &mut VecDeque<u32>,
-    managed_windows: &[Window],
+    managed_windows: &[Window<H>],
     direction: Direction,
 ) -> Option<u32> {
     while let Some(window) = if direction == Direction::Forward {
@@ -177,8 +178,8 @@ fn next_valid_scratchpad_pid(
 
 /// Check if the scratchpad is visible on the current tag.
 /// Returns `false` immediately if the scratchpad name isn't defined in the config
-fn is_scratchpad_visible<C: Config, SERVER: DisplayServer>(
-    manager: &Manager<C, SERVER>,
+fn is_scratchpad_visible<H: Handle, C: Config, SERVER: DisplayServer<H>>(
+    manager: &Manager<H, C, SERVER>,
     scratchpad_name: &ScratchPadName,
 ) -> bool {
     // Like Try operator but returns false and only works on `Option`s
@@ -203,8 +204,8 @@ fn is_scratchpad_visible<C: Config, SERVER: DisplayServer>(
 }
 
 /// Handle the command to toggle the scratchpad
-pub fn toggle_scratchpad<C: Config, SERVER: DisplayServer>(
-    manager: &mut Manager<C, SERVER>,
+pub fn toggle_scratchpad<H: Handle, C: Config, SERVER: DisplayServer<H>>(
+    manager: &mut Manager<H, C, SERVER>,
     name: &ScratchPadName,
 ) -> Option<bool> {
     let current_tag = &manager.state.focus_manager.tag(0)?;
@@ -270,10 +271,10 @@ pub fn toggle_scratchpad<C: Config, SERVER: DisplayServer>(
 }
 
 /// Attaches the `WindowHandle` or the currently selected window to the selected `scratchpad`
-pub fn attach_scratchpad<C: Config, SERVER: DisplayServer>(
-    window: Option<WindowHandle>,
+pub fn attach_scratchpad<H: Handle, C: Config, SERVER: DisplayServer<H>>(
+    window: Option<WindowHandle<H>>,
     scratchpad: &ScratchPadName,
-    manager: &mut Manager<C, SERVER>,
+    manager: &mut Manager<H, C, SERVER>,
 ) -> Option<bool> {
     // If `None`, replace with current window
     let window_handle = {
@@ -355,10 +356,10 @@ pub fn attach_scratchpad<C: Config, SERVER: DisplayServer>(
 /// Release a scratchpad to become a normal window. When tag is None, use current active tag as the
 /// destination. Window can be a handle to select a specific window, the name of a scratchpad or
 /// none to select the current window.
-pub fn release_scratchpad<C: Config, SERVER: DisplayServer>(
-    window: ReleaseScratchPadOption,
+pub fn release_scratchpad<H: Handle, C: Config, SERVER: DisplayServer<H>>(
+    window: ReleaseScratchPadOption<H>,
     tag: Option<TagId>,
-    manager: &mut Manager<C, SERVER>,
+    manager: &mut Manager<H, C, SERVER>,
 ) -> Option<bool> {
     let destination_tag =
         tag.or_else(|| manager.state.focus_manager.tag_history.front().copied())?;
@@ -470,8 +471,8 @@ pub enum Direction {
 
 /// Cycles the currently visible scratchpad window given the scratchpads name. Only visible
 /// scratchpads will be handled, otherwise ignored
-pub fn cycle_scratchpad_window<C: Config, SERVER: DisplayServer>(
-    manager: &mut Manager<C, SERVER>,
+pub fn cycle_scratchpad_window<H: Handle, C: Config, SERVER: DisplayServer<H>>(
+    manager: &mut Manager<H, C, SERVER>,
     scratchpad_name: &ScratchPadName,
     direction: Direction,
 ) -> Option<bool> {
@@ -525,7 +526,7 @@ pub fn cycle_scratchpad_window<C: Config, SERVER: DisplayServer>(
 
 #[cfg(test)]
 mod tests {
-    use crate::{config::ScratchPad, models::ScratchPadName};
+    use crate::{config::ScratchPad, models::{ScratchPadName, MockHandle}};
 
     use super::*;
 
@@ -537,7 +538,7 @@ mod tests {
         let first_tag = manager.state.tags.get(1).unwrap().id;
 
         let mock_window = 1_u32;
-        let window_handle = WindowHandle::MockHandle(mock_window as i32);
+        let window_handle = WindowHandle::<MockHandle>(mock_window as i32);
         manager.window_created_handler(Window::new(window_handle, None, Some(mock_window)), -1, -1);
         // Make sure the window is on the first tag
         manager.command_handler(&Command::SendWindowToTag {
@@ -572,7 +573,7 @@ mod tests {
         let first_tag = manager.state.tags.get(1).unwrap().id;
 
         let mock_window = 1_u32;
-        let window_handle = WindowHandle::MockHandle(mock_window as i32);
+        let window_handle = WindowHandle::<MockHandle>(mock_window as i32);
         manager.window_created_handler(Window::new(window_handle, None, Some(mock_window)), -1, -1);
         // Make sure the window is on the first tag
         manager.command_handler(&Command::SendWindowToTag {
@@ -606,7 +607,7 @@ mod tests {
         let nsp_tag = manager.state.tags.get_hidden_by_label("NSP").unwrap().id;
 
         let mock_window = 1_u32;
-        let window_handle = WindowHandle::MockHandle(mock_window as i32);
+        let window_handle = WindowHandle::<MockHandle>(mock_window as i32);
         let scratchpad_name: ScratchPadName = "Alacritty".into();
         manager.window_created_handler(Window::new(window_handle, None, Some(mock_window)), -1, -1);
         manager.state.scratchpads.push(ScratchPad {
@@ -678,7 +679,7 @@ mod tests {
             .insert(scratchpad_name.clone(), VecDeque::from([mock_window1]));
         manager.window_created_handler(
             Window::new(
-                WindowHandle::MockHandle(mock_window1 as i32),
+                WindowHandle::<MockHandle>(mock_window1 as i32),
                 None,
                 Some(mock_window1),
             ),
@@ -690,7 +691,7 @@ mod tests {
 
         // Release Scratchpad
         manager.command_handler(&Command::ReleaseScratchPad {
-            window: ReleaseScratchPadOption::Handle(WindowHandle::MockHandle(mock_window1 as i32)),
+            window: ReleaseScratchPadOption::Handle(WindowHandle::<MockHandle>(mock_window1 as i32)),
             tag: Some(expected_tag),
         });
 
@@ -725,7 +726,7 @@ mod tests {
         );
         for window in [mock_window1, mock_window2, mock_window3] {
             manager.window_created_handler(
-                Window::new(WindowHandle::MockHandle(window as i32), None, Some(window)),
+                Window::new(WindowHandle::<MockHandle>(window as i32), None, Some(window)),
                 -1,
                 -1,
             );
@@ -735,7 +736,7 @@ mod tests {
 
         // Release Scratchpad
         manager.command_handler(&Command::ReleaseScratchPad {
-            window: ReleaseScratchPadOption::Handle(WindowHandle::MockHandle(mock_window1 as i32)),
+            window: ReleaseScratchPadOption::Handle(WindowHandle::<MockHandle>(mock_window1 as i32)),
             tag: Some(expected_tag),
         });
 
@@ -797,7 +798,7 @@ mod tests {
         );
         for mock_window in [mock_window1, mock_window2, mock_window3] {
             let mut window = Window::new(
-                WindowHandle::MockHandle(mock_window as i32),
+                WindowHandle::<MockHandle>(mock_window as i32),
                 None,
                 Some(mock_window),
             );
@@ -810,7 +811,7 @@ mod tests {
 
         // Attach Scratchpad
         manager.command_handler(&Command::AttachScratchPad {
-            window: Some(WindowHandle::MockHandle(mock_window1 as i32)),
+            window: Some(WindowHandle::<MockHandle>(mock_window1 as i32)),
             scratchpad: scratchpad_name.clone(),
         });
 
@@ -853,7 +854,7 @@ mod tests {
 
         let mut managed_windows = [mock_window1, mock_window2, mock_window3, mock_window4]
             .iter()
-            .map(|pid| Window::new(WindowHandle::MockHandle(*pid as i32), None, Some(*pid)))
+            .map(|pid| Window::new(WindowHandle::<MockHandle>(*pid as i32), None, Some(*pid)))
             .collect::<Vec<Window>>();
         let mut scratchpad =
             VecDeque::from([mock_window1, mock_window2, mock_window3, mock_window4]);
@@ -887,7 +888,7 @@ mod tests {
 
         let mut managed_windows = [mock_window1, mock_window2, mock_window3, mock_window4]
             .iter()
-            .map(|pid| Window::new(WindowHandle::MockHandle(*pid as i32), None, Some(*pid)))
+            .map(|pid| Window::new(WindowHandle::<MockHandle>(*pid as i32), None, Some(*pid)))
             .collect::<Vec<Window>>();
         let mut scratchpad =
             VecDeque::from([mock_window1, mock_window2, mock_window3, mock_window4]);
@@ -914,8 +915,8 @@ mod tests {
     #[test]
     #[allow(clippy::too_many_lines)]
     fn cycle_scratchpad_window_test() {
-        fn is_visible<C: Config, SERVER: DisplayServer>(
-            manager: &Manager<C, SERVER>,
+        fn is_visible<H: Handle, C: Config, SERVER: DisplayServer<H>>(
+            manager: &Manager<H, C, SERVER>,
             pid: u32,
             nsp_tag: TagId,
         ) -> bool {
@@ -927,8 +928,8 @@ mod tests {
                 .map(|w| w.visible() && !w.has_tag(&nsp_tag))
                 .unwrap()
         }
-        fn is_only_first_visible<C: Config, SERVER: DisplayServer>(
-            manager: &Manager<C, SERVER>,
+        fn is_only_first_visible<H: Handle, C: Config, SERVER: DisplayServer<H>>(
+            manager: &Manager<H, C, SERVER>,
             mut pids: impl Iterator<Item = u32>,
             nsp_tag: TagId,
         ) -> bool {
@@ -956,7 +957,7 @@ mod tests {
 
         for mock_window in [mock_window1, mock_window2, mock_window3] {
             let mut window = Window::new(
-                WindowHandle::MockHandle(mock_window as i32),
+                WindowHandle::<MockHandle>(mock_window as i32),
                 None,
                 Some(mock_window),
             );
@@ -1066,7 +1067,7 @@ mod tests {
 
         for mock_window in [mock_window1, mock_window2, mock_window3] {
             let mut window = Window::new(
-                WindowHandle::MockHandle(mock_window as i32),
+                WindowHandle::<MockHandle>(mock_window as i32),
                 None,
                 Some(mock_window),
             );
@@ -1098,7 +1099,7 @@ mod tests {
                 .window(&manager.state.windows)
                 .unwrap()
                 .handle,
-            WindowHandle::MockHandle(1),
+            WindowHandle::<MockHandle>(1),
             "Initially the first window (1) should be focused"
         );
 
@@ -1110,7 +1111,7 @@ mod tests {
                 .window(&manager.state.windows)
                 .unwrap()
                 .handle,
-            WindowHandle::MockHandle(2),
+            WindowHandle::<MockHandle>(2),
             "After 1 down window (2) should be focused"
         );
 
@@ -1122,7 +1123,7 @@ mod tests {
                 .window(&manager.state.windows)
                 .unwrap()
                 .handle,
-            WindowHandle::MockHandle(3),
+            WindowHandle::<MockHandle>(3),
             "After 2 down window (3) should be focused"
         );
 
@@ -1134,7 +1135,7 @@ mod tests {
                 .window(&manager.state.windows)
                 .unwrap()
                 .handle,
-            WindowHandle::MockHandle(1),
+            WindowHandle::<MockHandle>(1),
             "After 3 down window (1) should be focused (cycle back)"
         );
 
@@ -1146,7 +1147,7 @@ mod tests {
                 .window(&manager.state.windows)
                 .unwrap()
                 .handle,
-            WindowHandle::MockHandle(3),
+            WindowHandle::<MockHandle>(3),
             "After 3 down and 1 up window (3) should be focused (cycle back)"
         );
 
@@ -1158,7 +1159,7 @@ mod tests {
                 .window(&manager.state.windows)
                 .unwrap()
                 .handle,
-            WindowHandle::MockHandle(2),
+            WindowHandle::<MockHandle>(2),
             "After 3 down and 2 up window (2) should be focused"
         );
     }
@@ -1176,7 +1177,7 @@ mod tests {
 
         for mock_window in [mock_window1, mock_window2, mock_window3] {
             let mut window = Window::new(
-                WindowHandle::MockHandle(mock_window as i32),
+                WindowHandle::<MockHandle>(mock_window as i32),
                 None,
                 Some(mock_window),
             );
@@ -1208,7 +1209,7 @@ mod tests {
                 .window(&manager.state.windows)
                 .unwrap()
                 .handle,
-            WindowHandle::MockHandle(1),
+            WindowHandle::<MockHandle>(1),
             "Initially the first window (1) should be focused"
         );
 
@@ -1220,7 +1221,7 @@ mod tests {
                 .window(&manager.state.windows)
                 .unwrap()
                 .handle,
-            WindowHandle::MockHandle(3),
+            WindowHandle::<MockHandle>(3),
             "After 1 up window (3) should be focused (scratchpad window)"
         );
 
@@ -1232,7 +1233,7 @@ mod tests {
                 .window(&manager.state.windows)
                 .unwrap()
                 .handle,
-            WindowHandle::MockHandle(1),
+            WindowHandle::<MockHandle>(1),
             "After focusing the scratchpad and then focusing the top, window (1) should be focused"
         );
     }
@@ -1244,7 +1245,7 @@ mod tests {
         let second_tag = manager.state.tags.get(2).unwrap().id;
 
         let scratchpad_pid = 1_u32;
-        let scratchpad_handle = WindowHandle::MockHandle(scratchpad_pid as i32);
+        let scratchpad_handle = WindowHandle::<MockHandle>(scratchpad_pid as i32);
         let scratchpad_name: ScratchPadName = "Alacritty".into();
         let mut scratchpad = Window::new(scratchpad_handle, None, Some(scratchpad_pid));
         scratchpad.tag = Some(second_tag);
@@ -1263,7 +1264,7 @@ mod tests {
             .insert(scratchpad_name.clone(), VecDeque::from([scratchpad_pid]));
 
         let window_pid = 2_u32;
-        let window_handle = WindowHandle::MockHandle(window_pid as i32);
+        let window_handle = WindowHandle::<MockHandle>(window_pid as i32);
         manager.window_created_handler(Window::new(window_handle, None, Some(window_pid)), -1, -1);
 
         manager.command_handler(&Command::ToggleScratchPad(scratchpad_name.clone()));

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -1,13 +1,13 @@
 #![allow(clippy::wildcard_imports)]
 
 use super::*;
-use crate::models::TagId;
+use crate::models::{TagId, Handle};
 use crate::state::State;
 use crate::{display_action::DisplayAction, models::FocusBehaviour};
 
-impl State {
+impl<H: Handle> State<H> {
     /// Focuses a window based upon the `FocusBehaviour`
-    pub fn handle_window_focus(&mut self, handle: &WindowHandle) {
+    pub fn handle_window_focus(&mut self, handle: &WindowHandle<H>) {
         match self.focus_manager.behaviour {
             FocusBehaviour::Sloppy if self.focus_manager.sloppy_mouse_follows_focus => {
                 let act = DisplayAction::MoveMouseOver(*handle, false);
@@ -18,7 +18,7 @@ impl State {
     }
 
     /// Focuses the given window.
-    pub fn focus_window(&mut self, handle: &WindowHandle) {
+    pub fn focus_window(&mut self, handle: &WindowHandle<H>) {
         let Some(window) = self.focus_window_work(handle) else {
             return;
         };
@@ -120,7 +120,7 @@ impl State {
 
     /// Focuses the window containing a given point.
     pub fn focus_window_with_point(&mut self, x: i32, y: i32) {
-        let handle_found: Option<WindowHandle> = self
+        let handle_found: Option<WindowHandle<H>> = self
             .windows
             .iter()
             .filter(|x| x.can_focus())
@@ -134,7 +134,7 @@ impl State {
     }
 
     /// Validates that the given window is focused.
-    pub fn validate_focus_at(&mut self, handle: &WindowHandle) {
+    pub fn validate_focus_at(&mut self, handle: &WindowHandle<H>) {
         // If the window is already focused do nothing.
         if let Some(current) = self.focus_manager.window(&self.windows) {
             if &current.handle == handle {
@@ -157,7 +157,7 @@ impl State {
         let Some(ws) = self.workspaces.iter().find(|ws| ws.contains_point(x, y)) else {
             return;
         };
-        let mut dists: Vec<(i32, &Window)> = self
+        let mut dists: Vec<(i32, &Window<H>)> = self
             .windows
             .iter()
             .filter(|x| ws.is_managed(x) && x.can_focus())
@@ -186,7 +186,7 @@ impl State {
         true
     }
 
-    fn focus_window_work(&mut self, handle: &WindowHandle) -> Option<Window> {
+    fn focus_window_work(&mut self, handle: &WindowHandle<H>) -> Option<Window<H>> {
         if self.screens.iter().any(|s| &s.root == handle) {
             let act = DisplayAction::Unfocus(None, false);
             self.actions.push_back(act);
@@ -194,7 +194,7 @@ impl State {
             return None;
         }
         // Find the handle in our managed windows.
-        let found: &Window = self.windows.iter().find(|w| &w.handle == handle)?;
+        let found: &Window<H> = self.windows.iter().find(|w| &w.handle == handle)?;
         // Docks don't want to get focus. If they do weird things happen. They don't get events...
         if !found.is_managed() {
             return None;
@@ -261,7 +261,7 @@ impl State {
 }
 
 // Square root not needed as we are only interested in the comparison.
-fn distance(window: &Window, x: i32, y: i32) -> i32 {
+fn distance<H: Handle>(window: &Window<H>, x: i32, y: i32) -> i32 {
     // (x_2-x_1)²+(y_2-y_1)²
     let (wx, wy) = window.calculated_xyhw().center();
     let xs = (wx - x) * (wx - x);
@@ -272,7 +272,7 @@ fn distance(window: &Window, x: i32, y: i32) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Manager;
+    use crate::{Manager, models::MockHandle};
 
     #[test]
     fn focusing_a_workspace_should_make_it_active() {
@@ -298,12 +298,12 @@ mod tests {
             .state
             .focus_workspace(&manager.state.workspaces[0].clone());
         manager.window_created_handler(
-            Window::new(WindowHandle::MockHandle(1), None, None),
+            Window::new(WindowHandle::<MockHandle>(1), None, None),
             -1,
             -1,
         );
         manager.window_created_handler(
-            Window::new(WindowHandle::MockHandle(2), None, None),
+            Window::new(WindowHandle::<MockHandle>(2), None, None),
             -1,
             -1,
         );
@@ -349,12 +349,12 @@ mod tests {
         let mut manager = Manager::new_test(vec![]);
         manager.screen_create_handler(Screen::default());
         manager.window_created_handler(
-            Window::new(WindowHandle::MockHandle(1), None, None),
+            Window::new(WindowHandle::<MockHandle>(1), None, None),
             -1,
             -1,
         );
         manager.window_created_handler(
-            Window::new(WindowHandle::MockHandle(2), None, None),
+            Window::new(WindowHandle::<MockHandle>(2), None, None),
             -1,
             -1,
         );
@@ -373,7 +373,7 @@ mod tests {
     fn focusing_the_same_window_shouldnt_add_to_the_history() {
         let mut manager = Manager::new_test(vec![]);
         manager.screen_create_handler(Screen::default());
-        let window = Window::new(WindowHandle::MockHandle(1), None, None);
+        let window = Window::new(WindowHandle::<MockHandle>(1), None, None);
         manager.window_created_handler(window.clone(), -1, -1);
         manager.state.focus_window(&window.handle);
         let start_length = manager.state.focus_manager.workspace_history.len();
@@ -439,7 +439,7 @@ mod tests {
         manager.screen_create_handler(Screen::default());
         manager.screen_create_handler(Screen::default());
         manager.screen_create_handler(Screen::default());
-        let mut window = Window::new(WindowHandle::MockHandle(1), None, None);
+        let mut window = Window::new(WindowHandle::<MockHandle>(1), None, None);
         window.tag(&2);
         manager.state.windows.push(window.clone());
         manager.state.focus_window(&window.handle);
@@ -453,7 +453,7 @@ mod tests {
         manager.screen_create_handler(Screen::default());
         manager.screen_create_handler(Screen::default());
         manager.screen_create_handler(Screen::default());
-        let mut window = Window::new(WindowHandle::MockHandle(1), None, None);
+        let mut window = Window::new(WindowHandle::<MockHandle>(1), None, None);
         window.tag(&2);
         manager.state.windows.push(window.clone());
         manager.state.focus_window(&window.handle);
@@ -470,7 +470,7 @@ mod tests {
     fn focusing_an_empty_tag_should_unfocus_any_focused_window() {
         let mut manager = Manager::new_test(vec![]);
         manager.screen_create_handler(Screen::default());
-        let mut window = Window::new(WindowHandle::MockHandle(1), None, None);
+        let mut window = Window::new(WindowHandle::<MockHandle>(1), None, None);
         window.tag(&1);
         manager.state.windows.push(window.clone());
         manager.state.focus_window(&window.handle);

--- a/leftwm-core/src/handlers/goto_tag_handler.rs
+++ b/leftwm-core/src/handlers/goto_tag_handler.rs
@@ -1,6 +1,6 @@
-use crate::{models::TagId, state::State};
+use crate::{models::{TagId, Handle}, state::State};
 
-impl State {
+impl<H: Handle> State<H> {
     pub fn goto_tag_handler(&mut self, tag_id: TagId) -> Option<bool> {
         if tag_id > self.tags.len_normal() || tag_id < 1 {
             return Some(false);

--- a/leftwm-core/src/handlers/screen_create_handler.rs
+++ b/leftwm-core/src/handlers/screen_create_handler.rs
@@ -1,12 +1,13 @@
 use super::{Manager, Screen, Workspace};
 use crate::config::Config;
 use crate::display_servers::DisplayServer;
+use crate::models::Handle;
 
-impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
+impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
     /// Process a collection of events, and apply the changes to a manager.
     ///
     /// Returns `true` if changes need to be rendered.
-    pub fn screen_create_handler(&mut self, screen: Screen) -> bool {
+    pub fn screen_create_handler(&mut self, screen: Screen<H>) -> bool {
         tracing::trace!("Screen create: {:?}", screen);
 
         let tag_index = self.state.workspaces.len();

--- a/leftwm-core/src/handlers/window_move_handler.rs
+++ b/leftwm-core/src/handlers/window_move_handler.rs
@@ -1,12 +1,12 @@
 use super::{Manager, Window, WindowHandle, Workspace};
 use crate::config::Config;
 use crate::display_servers::DisplayServer;
-use crate::models::Xyhw;
+use crate::models::{Xyhw, Handle};
 
-impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
+impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
     pub fn window_move_handler(
         &mut self,
-        handle: &WindowHandle,
+        handle: &WindowHandle<H>,
         offset_x: i32,
         offset_y: i32,
     ) -> bool {
@@ -24,7 +24,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
     }
 }
 
-fn process_window(window: &mut Window, offset_x: i32, offset_y: i32) {
+fn process_window<H: Handle>(window: &mut Window<H>, offset_x: i32, offset_y: i32) {
     let mut offset = window.get_floating_offsets().unwrap_or_default();
     let start = window.start_loc.unwrap_or_default();
     offset.set_x(start.x() + offset_x);
@@ -33,7 +33,7 @@ fn process_window(window: &mut Window, offset_x: i32, offset_y: i32) {
 }
 
 // Update the window for the workspace it is currently on.
-fn snap_to_workspace(window: &mut Window, workspaces: &[Workspace]) -> bool {
+fn snap_to_workspace<H: Handle>(window: &mut Window<H>, workspaces: &[Workspace]) -> bool {
     // Check that the workspace contains the window.
     let loc = window.calculated_xyhw();
     let (x, y) = loc.center();
@@ -46,7 +46,7 @@ fn snap_to_workspace(window: &mut Window, workspaces: &[Workspace]) -> bool {
 
 // To be snapable, the window must be inside the workspace AND the a side must be close to
 // the workspaces edge.
-fn should_snap(window: &mut Window, workspace: &Workspace, loc: Xyhw) -> bool {
+fn should_snap<H: Handle>(window: &mut Window<H>, workspace: &Workspace, loc: Xyhw) -> bool {
     if window.must_float() {
         return false;
     }

--- a/leftwm-core/src/handlers/window_resize_handler.rs
+++ b/leftwm-core/src/handlers/window_resize_handler.rs
@@ -1,11 +1,12 @@
 use super::{Manager, Window, WindowHandle};
 use crate::config::Config;
 use crate::display_servers::DisplayServer;
+use crate::models::Handle;
 
-impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
+impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
     pub fn window_resize_handler(
         &mut self,
-        handle: &WindowHandle,
+        handle: &WindowHandle<H>,
         offset_w: i32,
         offset_h: i32,
     ) -> bool {
@@ -17,7 +18,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
     }
 }
 
-fn process_window(window: &mut Window, offset_w: i32, offset_h: i32) {
+fn process_window<H: Handle>(window: &mut Window<H>, offset_w: i32, offset_h: i32) {
     window.set_floating(true);
     let mut offset = window.get_floating_offsets().unwrap_or_default();
     let start = window.start_loc.unwrap_or_default();

--- a/leftwm-core/src/lib.rs
+++ b/leftwm-core/src/lib.rs
@@ -41,6 +41,6 @@ pub use models::Window;
 pub use models::Workspace;
 pub use state::State;
 pub use utils::child_process;
-pub use utils::command_pipe::CommandPipe;
+pub use utils::command_pipe::{pipe_name, CommandPipe};
 pub use utils::return_pipe::ReturnPipe;
 pub use utils::state_socket::StateSocket;

--- a/leftwm-core/src/models.rs
+++ b/leftwm-core/src/models.rs
@@ -32,6 +32,8 @@ pub use screen::{BBox, Screen};
 pub use size::Size;
 pub use window::Window;
 pub use window::WindowHandle;
+pub use window::Handle;
+pub(crate) use window::MockHandle;
 pub use window_change::WindowChange;
 pub use window_state::WindowState;
 pub use window_type::WindowType;
@@ -45,4 +47,4 @@ pub use tag::Tags;
 
 pub type TagId = usize;
 pub type WorkspaceId = usize;
-type MaybeWindowHandle = Option<WindowHandle>;
+type MaybeWindowHandle<H> = Option<WindowHandle<H>>;

--- a/leftwm-core/src/models/dock_area.rs
+++ b/leftwm-core/src/models/dock_area.rs
@@ -1,6 +1,7 @@
 use crate::models::Xyhw;
 use crate::models::XyhwBuilder;
 
+use super::Handle;
 use super::Screen;
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -22,51 +23,51 @@ pub struct DockArea {
     pub left_end_y: i32,
 }
 
-impl From<&[i64]> for DockArea {
-    fn from(slice: &[i64]) -> Self {
-        Self {
-            left: slice[0] as i32,
-            right: slice[1] as i32,
-            top: slice[2] as i32,
-            bottom: slice[3] as i32,
-            left_start_y: slice[4] as i32,
-            left_end_y: slice[5] as i32,
-            right_start_y: slice[6] as i32,
-            right_end_y: slice[7] as i32,
-            top_start_x: slice[8] as i32,
-            top_end_x: slice[9] as i32,
-            bottom_start_x: slice[10] as i32,
-            bottom_end_x: slice[11] as i32,
-        }
-    }
-}
-
-impl From<&[i32]> for DockArea {
-    fn from(slice: &[i32]) -> Self {
-        Self {
-            left: slice[0],
-            right: slice[1],
-            top: slice[2],
-            bottom: slice[3],
-            left_start_y: slice[4],
-            left_end_y: slice[5],
-            right_start_y: slice[6],
-            right_end_y: slice[7],
-            top_start_x: slice[8],
-            top_end_x: slice[9],
-            bottom_start_x: slice[10],
-            bottom_end_x: slice[11],
-        }
-    }
-}
+// impl From<&[i64]> for DockArea {
+//     fn from(slice: &[i64]) -> Self {
+//         Self {
+//             left: slice[0] as i32,
+//             right: slice[1] as i32,
+//             top: slice[2] as i32,
+//             bottom: slice[3] as i32,
+//             left_start_y: slice[4] as i32,
+//             left_end_y: slice[5] as i32,
+//             right_start_y: slice[6] as i32,
+//             right_end_y: slice[7] as i32,
+//             top_start_x: slice[8] as i32,
+//             top_end_x: slice[9] as i32,
+//             bottom_start_x: slice[10] as i32,
+//             bottom_end_x: slice[11] as i32,
+//         }
+//     }
+// }
+//
+// impl From<&[i32]> for DockArea {
+//     fn from(slice: &[i32]) -> Self {
+//         Self {
+//             left: slice[0],
+//             right: slice[1],
+//             top: slice[2],
+//             bottom: slice[3],
+//             left_start_y: slice[4],
+//             left_end_y: slice[5],
+//             right_start_y: slice[6],
+//             right_end_y: slice[7],
+//             top_start_x: slice[8],
+//             top_end_x: slice[9],
+//             bottom_start_x: slice[10],
+//             bottom_end_x: slice[11],
+//         }
+//     }
+// }
 
 impl DockArea {
     #[must_use]
-    pub fn as_xyhw(
+    pub fn as_xyhw<H: Handle>(
         &self,
         screens_height: i32,
         screens_width: i32,
-        screen: &Screen,
+        screen: &Screen<H>,
     ) -> Option<Xyhw> {
         if self.top > 0 {
             return Some(self.xyhw_from_top(screen.bbox.y));

--- a/leftwm-core/src/models/dto.rs
+++ b/leftwm-core/src/models/dto.rs
@@ -1,6 +1,8 @@
 use crate::state::State;
 use serde::{Deserialize, Serialize};
 
+use super::Handle;
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Viewport {
     pub id: usize,
@@ -113,8 +115,8 @@ fn viewport_into_display_workspace(
     }
 }
 
-impl From<&State> for ManagerState {
-    fn from(state: &State) -> Self {
+impl<H: Handle> From<&State<H>> for ManagerState {
+    fn from(state: &State<H>) -> Self {
         let mut viewports: Vec<Viewport> = vec![];
         // tags_len = if tags_len == 0 { 0 } else { tags_len - 1 };
         let working_tags = state

--- a/leftwm-core/src/models/focus_manager.rs
+++ b/leftwm-core/src/models/focus_manager.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 
 use super::MaybeWindowHandle;
+use super::window::Handle;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FocusBehaviour {
@@ -34,19 +35,21 @@ impl FocusBehaviour {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct FocusManager {
+pub struct FocusManager<H: Handle> {
     pub behaviour: FocusBehaviour,
     pub focus_new_windows: bool,
     pub workspace_history: VecDeque<usize>,
-    pub window_history: VecDeque<MaybeWindowHandle>,
+    #[serde(bound = "")]
+    pub window_history: VecDeque<MaybeWindowHandle<H>>,
     pub tag_history: VecDeque<TagId>,
-    pub tags_last_window: HashMap<TagId, WindowHandle>,
+    #[serde(bound = "")]
+    pub tags_last_window: HashMap<TagId, WindowHandle<H>>,
     pub sloppy_mouse_follows_focus: bool,
     pub create_follows_cursor: bool,
     pub last_mouse_position: Option<(i32, i32)>,
 }
 
-impl FocusManager {
+impl<H: Handle> FocusManager<H> {
     pub fn new(config: &impl Config) -> Self {
         Self {
             behaviour: config.focus_behaviour(),
@@ -91,7 +94,7 @@ impl FocusManager {
 
     /// Return the currently focused window.
     #[must_use]
-    pub fn window<'a, 'b>(&self, windows: &'a [Window]) -> Option<&'b Window>
+    pub fn window<'a, 'b>(&self, windows: &'a [Window<H>]) -> Option<&'b Window<H>>
     where
         'a: 'b,
     {
@@ -103,7 +106,7 @@ impl FocusManager {
     }
 
     /// Return the currently focused window.
-    pub fn window_mut<'a, 'b>(&self, windows: &'a mut [Window]) -> Option<&'b mut Window>
+    pub fn window_mut<'a, 'b>(&self, windows: &'a mut [Window<H>]) -> Option<&'b mut Window<H>>
     where
         'a: 'b,
     {

--- a/leftwm-core/src/models/mode.rs
+++ b/leftwm-core/src/models/mode.rs
@@ -1,16 +1,24 @@
+use std::fmt::Debug;
+
 use crate::models::WindowHandle;
 use serde::{Deserialize, Serialize};
 
+use super::window::Handle;
+
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Mode {
-    ReadyToResize(WindowHandle),
-    ReadyToMove(WindowHandle),
-    ResizingWindow(WindowHandle),
-    MovingWindow(WindowHandle),
+pub enum Mode<H: Handle> {
+    #[serde(bound = "")]
+    ReadyToResize(WindowHandle<H>),
+    #[serde(bound = "")]
+    ReadyToMove(WindowHandle<H>),
+    #[serde(bound = "")]
+    ResizingWindow(WindowHandle<H>),
+    #[serde(bound = "")]
+    MovingWindow(WindowHandle<H>),
     Normal,
 }
 
-impl Default for Mode {
+impl<H: Handle> Default for Mode<H> {
     fn default() -> Self {
         Self::Normal
     }

--- a/leftwm-core/src/models/screen.rs
+++ b/leftwm-core/src/models/screen.rs
@@ -1,12 +1,12 @@
-use super::{DockArea, Size, WindowHandle, WorkspaceId};
+use super::{window::Handle, DockArea, Size, WindowHandle, WorkspaceId, MockHandle};
 use crate::config::Workspace;
 use serde::{Deserialize, Serialize};
 use std::convert::From;
-use x11_dl::xlib;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Screen {
-    pub root: WindowHandle,
+pub struct Screen<H: Handle> {
+    #[serde(bound = "")]
+    pub root: WindowHandle<H>,
     pub output: String,
     pub id: Option<WorkspaceId>,
     pub bbox: BBox,
@@ -22,11 +22,11 @@ pub struct BBox {
     pub height: i32,
 }
 
-impl Screen {
+impl<H: Handle> Screen<H> {
     #[must_use]
-    pub const fn new(bbox: BBox, output: String) -> Self {
+    pub fn new(bbox: BBox, output: String) -> Self {
         Self {
-            root: WindowHandle::MockHandle(0),
+            root: WindowHandle::<H>(H::default()),
             output,
             bbox,
             max_window_width: None,
@@ -70,7 +70,7 @@ impl BBox {
     }
 }
 
-impl From<&Workspace> for Screen {
+impl<H: Handle> From<&Workspace> for Screen<H> {
     fn from(wsc: &Workspace) -> Self {
         Self {
             bbox: BBox {
@@ -86,81 +86,81 @@ impl From<&Workspace> for Screen {
     }
 }
 
-impl From<x11_dl::xrandr::XRRCrtcInfo> for Screen {
-    fn from(root: x11_dl::xrandr::XRRCrtcInfo) -> Self {
-        Self {
-            bbox: BBox {
-                x: root.x,
-                y: root.y,
-                width: root.width as i32,
-                height: root.height as i32,
-            },
-            ..Default::default()
-        }
-    }
-}
+// impl<H> From<x11_dl::xrandr::XRRCrtcInfo> for Screen<H> {
+//     fn from(root: x11_dl::xrandr::XRRCrtcInfo) -> Self {
+//         Self {
+//             bbox: BBox {
+//                 x: root.x,
+//                 y: root.y,
+//                 width: root.width as i32,
+//                 height: root.height as i32,
+//             },
+//             ..Default::default()
+//         }
+//     }
+// }
+//
+// impl<H> From<x11rb::protocol::randr::GetCrtcInfoReply> for Screen<H> {
+//     fn from(root: x11rb::protocol::randr::GetCrtcInfoReply) -> Self {
+//         Self {
+//             bbox: BBox {
+//                 x: root.x as i32,
+//                 y: root.y as i32,
+//                 width: root.width as i32,
+//                 height: root.height as i32,
+//             },
+//             ..Default::default()
+//         }
+//     }
+// }
+//
+// impl<H> From<&xlib::XWindowAttributes> for Screen<H> {
+//     fn from(root: &xlib::XWindowAttributes) -> Self {
+//         Self {
+//             root: root.root.into(),
+//             bbox: BBox {
+//                 height: root.height,
+//                 width: root.width,
+//                 x: root.x,
+//                 y: root.y,
+//             },
+//             ..Default::default()
+//         }
+//     }
+// }
+//
+// impl<H> From<&x11_dl::xinerama::XineramaScreenInfo> for Screen<H> {
+//     fn from(root: &x11_dl::xinerama::XineramaScreenInfo) -> Self {
+//         Self {
+//             bbox: BBox {
+//                 height: root.height.into(),
+//                 width: root.width.into(),
+//                 x: root.x_org.into(),
+//                 y: root.y_org.into(),
+//             },
+//             ..Default::default()
+//         }
+//     }
+// }
+//
+// impl<H> From<&x11rb::protocol::xinerama::ScreenInfo> for Screen<H> {
+//     fn from(root: &x11rb::protocol::xinerama::ScreenInfo) -> Self {
+//         Self {
+//             bbox: BBox {
+//                 height: root.height.into(),
+//                 width: root.width.into(),
+//                 x: root.x_org.into(),
+//                 y: root.y_org.into(),
+//             },
+//             ..Default::default()
+//         }
+//     }
+// }
 
-impl From<x11rb::protocol::randr::GetCrtcInfoReply> for Screen {
-    fn from(root: x11rb::protocol::randr::GetCrtcInfoReply) -> Self {
-        Self {
-            bbox: BBox {
-                x: root.x as i32,
-                y: root.y as i32,
-                width: root.width as i32,
-                height: root.height as i32,
-            },
-            ..Default::default()
-        }
-    }
-}
-
-impl From<&xlib::XWindowAttributes> for Screen {
-    fn from(root: &xlib::XWindowAttributes) -> Self {
-        Self {
-            root: root.root.into(),
-            bbox: BBox {
-                height: root.height,
-                width: root.width,
-                x: root.x,
-                y: root.y,
-            },
-            ..Default::default()
-        }
-    }
-}
-
-impl From<&x11_dl::xinerama::XineramaScreenInfo> for Screen {
-    fn from(root: &x11_dl::xinerama::XineramaScreenInfo) -> Self {
-        Self {
-            bbox: BBox {
-                height: root.height.into(),
-                width: root.width.into(),
-                x: root.x_org.into(),
-                y: root.y_org.into(),
-            },
-            ..Default::default()
-        }
-    }
-}
-
-impl From<&x11rb::protocol::xinerama::ScreenInfo> for Screen {
-    fn from(root: &x11rb::protocol::xinerama::ScreenInfo) -> Self {
-        Self {
-            bbox: BBox {
-                height: root.height.into(),
-                width: root.width.into(),
-                x: root.x_org.into(),
-                y: root.y_org.into(),
-            },
-            ..Default::default()
-        }
-    }
-}
-
-impl Default for Screen {
+impl<H: Handle> Default for Screen<H> {
     fn default() -> Self {
         Self {
-            root: WindowHandle::MockHandle(0),
+            root: WindowHandle::<H>(H::default()),
             output: String::default(),
             id: None,
             bbox: BBox {

--- a/leftwm-core/src/models/tag.rs
+++ b/leftwm-core/src/models/tag.rs
@@ -1,4 +1,4 @@
-use super::{TagId, Xyhw};
+use super::{TagId, Xyhw, Handle};
 use crate::{layouts::LayoutManager, Window, Workspace};
 use serde::{Deserialize, Serialize};
 
@@ -219,9 +219,9 @@ impl Tag {
         }
     }
 
-    pub fn update_windows(
+    pub fn update_windows<H: Handle>(
         &self,
-        windows: &mut [Window],
+        windows: &mut [Window<H>],
         workspace: &Workspace,
         layout_manager: &mut LayoutManager,
     ) {
@@ -260,12 +260,12 @@ impl Tag {
         } else {
             // Don't bother updating the other windows when a window is fullscreen.
             // Mark all windows for this workspace as visible.
-            let mut all_mine: Vec<&mut Window> =
+            let mut all_mine: Vec<&mut Window<H>> =
                 windows.iter_mut().filter(|w| w.has_tag(&self.id)).collect();
             all_mine.iter_mut().for_each(|w| w.set_visible(true));
 
             // Update the location / visibility of all non-floating windows.
-            let mut managed_nonfloat: Vec<&mut Window> = windows
+            let mut managed_nonfloat: Vec<&mut Window<H>> = windows
                 .iter_mut()
                 .filter(|w| w.has_tag(&self.id) && w.is_managed() && !w.floating())
                 .collect();

--- a/leftwm-core/src/models/window_change.rs
+++ b/leftwm-core/src/models/window_change.rs
@@ -1,3 +1,4 @@
+use super::Handle;
 use super::MaybeWindowHandle;
 use super::Window;
 use super::WindowHandle;
@@ -9,9 +10,9 @@ use crate::models::{Margins, XyhwChange};
 type MaybeName = Option<String>;
 
 #[derive(Debug, Clone)]
-pub struct WindowChange {
-    pub handle: WindowHandle,
-    pub transient: Option<MaybeWindowHandle>,
+pub struct WindowChange<H: Handle> {
+    pub handle: WindowHandle<H>,
+    pub transient: Option<MaybeWindowHandle<H>>,
     pub never_focus: Option<bool>,
     pub urgent: Option<bool>,
     pub name: Option<MaybeName>,
@@ -22,9 +23,9 @@ pub struct WindowChange {
     pub states: Option<Vec<WindowState>>,
 }
 
-impl WindowChange {
+impl<H: Handle> WindowChange<H> {
     #[must_use]
-    pub const fn new(h: WindowHandle) -> Self {
+    pub const fn new(h: WindowHandle<H>) -> Self {
         Self {
             handle: h,
             transient: None,
@@ -39,7 +40,7 @@ impl WindowChange {
         }
     }
 
-    pub fn update(self, window: &mut Window, container: Option<Xyhw>) -> bool {
+    pub fn update(self, window: &mut Window<H>, container: Option<Xyhw>) -> bool {
         let mut changed = false;
         if let Some(trans) = &self.transient {
             let changed_trans = window.transient.is_none() || &window.transient != trans;

--- a/leftwm-core/src/models/workspace.rs
+++ b/leftwm-core/src/models/workspace.rs
@@ -4,7 +4,7 @@ use leftwm_layouts::geometry::Rect;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-use super::WorkspaceId;
+use super::{WorkspaceId, Handle};
 
 /// Information for workspaces (screen divisions).
 #[derive(Serialize, Deserialize, Clone)]
@@ -108,7 +108,7 @@ impl Workspace {
 
     /// Returns true if the workspace is displays a given window.
     #[must_use]
-    pub fn is_displaying(&self, window: &Window) -> bool {
+    pub fn is_displaying<H: Handle>(&self, window: &Window<H>) -> bool {
         if let Some(tag) = &window.tag {
             return self.has_tag(tag);
         }
@@ -117,7 +117,7 @@ impl Workspace {
 
     /// Returns true if the workspace is to update the locations info of this window.
     #[must_use]
-    pub fn is_managed(&self, window: &Window) -> bool {
+    pub fn is_managed<H: Handle>(&self, window: &Window<H>) -> bool {
         self.is_displaying(window) && window.is_managed()
     }
 
@@ -201,7 +201,7 @@ impl Workspace {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{BBox, WindowHandle};
+    use crate::models::{BBox, WindowHandle, MockHandle};
 
     #[test]
     fn empty_ws_should_not_contain_window() {
@@ -214,7 +214,7 @@ mod tests {
             },
             0,
         );
-        let w = Window::new(WindowHandle::MockHandle(1), None, None);
+        let w = Window::new(WindowHandle::<MockHandle>(1), None, None);
         assert!(
             !subject.is_displaying(&w),
             "workspace incorrectly owns window"
@@ -235,7 +235,7 @@ mod tests {
         );
         let tag = crate::models::Tag::new(TAG_ID, "test");
         subject.show_tag(&tag.id);
-        let mut w = Window::new(WindowHandle::MockHandle(1), None, None);
+        let mut w = Window::new(WindowHandle::<MockHandle>(1), None, None);
         w.tag(&TAG_ID);
         assert!(subject.is_displaying(&w), "workspace should include window");
     }

--- a/leftwm-core/src/models/xyhw_change.rs
+++ b/leftwm-core/src/models/xyhw_change.rs
@@ -2,6 +2,8 @@ use crate::models::Window;
 use crate::models::Xyhw;
 use serde::{Deserialize, Serialize};
 
+use super::Handle;
+
 #[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Copy)]
 pub struct XyhwChange {
     pub x: Option<i32>,
@@ -83,7 +85,7 @@ impl XyhwChange {
         changed
     }
 
-    pub fn update_window_floating(&self, window: &mut Window) -> bool {
+    pub fn update_window_floating<H: Handle>(&self, window: &mut Window<H>) -> bool {
         let mut changed = false;
         if window.floating() {
             let mut current = window.calculated_xyhw();
@@ -97,7 +99,7 @@ impl XyhwChange {
     ///
     /// Souldn't panic; `window.strut` is modified to be a `Some` by
     /// the time of `unwrap()`
-    pub fn update_window_strut(&self, window: &mut Window) -> bool {
+    pub fn update_window_strut<H: Handle>(&self, window: &mut Window<H>) -> bool {
         let mut changed = if window.strut.is_none() {
             window.strut = Some(Xyhw::default());
             true

--- a/leftwm-core/src/utils/state_socket.rs
+++ b/leftwm-core/src/utils/state_socket.rs
@@ -1,4 +1,5 @@
 use crate::errors::{LeftError, Result};
+use crate::models::Handle;
 use crate::models::dto::ManagerState;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -55,7 +56,7 @@ impl StateSocket {
     /// # Errors
     /// Will return Err if a mut ref to the peer is unavailable.
     /// Will return error if state cannot be serialized
-    pub async fn write_manager_state(&mut self, raw_state: &crate::state::State) -> Result<()> {
+    pub async fn write_manager_state<H: Handle>(&mut self, raw_state: &crate::state::State<H>) -> Result<()> {
         if self.listener.is_some() {
             let state: ManagerState = raw_state.into();
             let mut json = serde_json::to_string(&state)?;

--- a/leftwm-core/src/utils/window_updater.rs
+++ b/leftwm-core/src/utils/window_updater.rs
@@ -1,8 +1,8 @@
 use crate::config::Config;
 use crate::display_servers::DisplayServer;
-use crate::models::Manager;
+use crate::models::{Manager, Handle};
 
-impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
+impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
     /*
      * step over all the windows for each workspace and updates all the things
      * based on the new state of the WM

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context, Result};
 use clap::{arg, command};
 use leftwm::BaseCommand;
-use leftwm_core::CommandPipe;
 use leftwm_core::ReturnPipe;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
@@ -13,7 +12,7 @@ use xdg::BaseDirectories;
 async fn main() -> Result<()> {
     let matches = get_command().get_matches();
 
-    let file_name = CommandPipe::pipe_name();
+    let file_name = leftwm_core::pipe_name();
     let file_path = BaseDirectories::with_prefix("leftwm")?
         .find_runtime_file(&file_name)
         .with_context(|| format!("ERROR: Couldn't find {}", file_name.display()))?;

--- a/leftwm/src/bin/leftwm-worker.rs
+++ b/leftwm/src/bin/leftwm-worker.rs
@@ -1,4 +1,6 @@
 use leftwm_core::Manager;
+use x11rb_display_server::X11rbWindowHandle;
+use xlib_display_server::XlibWindowHandle;
 use std::{env, panic, process::exit};
 
 #[cfg(feature = "x11rb")]
@@ -41,7 +43,7 @@ fn main() {
         match args.get(1) {
             #[cfg(feature = "xlib")]
             Some(name) if name == "xlib" => {
-                let manager = Manager::<leftwm::Config, XlibDisplayServer>::new(config);
+                let manager = Manager::<XlibWindowHandle, leftwm::Config, XlibDisplayServer>::new(config);
 
                 manager.register_child_hook();
                 //TODO: Error handling
@@ -50,7 +52,7 @@ fn main() {
 
             #[cfg(feature = "x11rb")]
             Some(name) if name == "x11rb" => {
-                let manager = Manager::<leftwm::Config, X11rbDisplayServer>::new(config);
+                let manager = Manager::<X11rbWindowHandle, leftwm::Config, X11rbDisplayServer>::new(config);
 
                 manager.register_child_hook();
                 //TODO: Error handling


### PR DESCRIPTION
Some changes that could be made for make `leftwm-core` backend-agnostic, which means removing it's dependency on `x11` and `x11rb` crates. This is intended to be integrated to https://github.com/leftwm/leftwm/pull/1221.

I'm keeping these changes in a separate branch because i'm not 100% sure of what i'm doing with this...