### PR TITLE
Move backend arg to leftwm main config

### DIFF
--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -34,6 +34,7 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
         let command_pipe = get_command_pipe().await?;
 
         self.call_up_scripts();
+        tracing::info!("LeftWM-core booted!");
         self.event_loop(state_socket, command_pipe).await
     }
 

--- a/leftwm-watchdog/Cargo.toml
+++ b/leftwm-watchdog/Cargo.toml
@@ -23,12 +23,8 @@ xdg = "2.2.0"
 tempfile = "3.2.0"
 
 [features]
-default = ["lefthk", "xlib", "x11rb"]
+default = ["lefthk"]
 lefthk = []
-
-# backends
-xlib = []
-x11rb = []
 
 # Sleep on restart
 slow-dm-fix = []

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -174,11 +174,29 @@ impl WindowHook {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum Backend {
+    #[cfg(feature = "xlib")]
+    XLib,
+    #[cfg(feature = "x11rb")]
+    X11rb,
+}
+
+impl Default for Backend {
+    fn default() -> Self {
+        #[cfg(feature = "xlib")]
+        return Backend::XLib;
+        #[cfg(not(feature = "xlib"))]
+        return Backend::X11rb;
+    }
+}
+
 /// General configuration
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(default)]
 pub struct Config {
+    pub backend: Backend,
     pub modkey: String,
     pub mousekey: Option<Modifier>,
     pub workspaces: Option<Vec<Workspace>>,

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -1,5 +1,7 @@
 use leftwm_core::models::{ScratchPad, Size};
 
+use crate::Backend;
+
 #[cfg(feature = "lefthk")]
 use super::{default_terminal, exit_strategy, BaseCommand, Keybind};
 use super::{Config, Default, FocusBehaviour, LayoutMode, ThemeConfig};
@@ -213,6 +215,8 @@ impl Default for Config {
         let layouts = leftwm_layouts::layouts::Layouts::default();
 
         Self {
+            // Using Backend's feature fallback
+            backend: Backend::default(),
             workspaces: Some(vec![]),
             tags: Some(tags),
             layouts: layouts.names(),


### PR DESCRIPTION
# Description

Move from requiring a `--backend` argument to a config option in the main config.

This allows hot-swapping backends and generally more flexibility when testing for both backends.

As I was already on it, this also clarifies boot logging (example below)
```
leftwm-worker booting...
Loading config file
Config file '/home/username/.config/leftwm/config.ron' found.
Loading X11rb backend
Refresh Rate: 60
LeftWM-core booted!
```

> [!NOTE]
> I plan on adding a `log_level` config option this way too, but this will have to wait 'til after your work so I don't cause conficts.

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
