### PR TITLE
Add config option for setting the log level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "x11-dl",
  "xdg",
 ]
 

--- a/display-servers/xlib-display-server/src/xwrap.rs
+++ b/display-servers/xlib-display-server/src/xwrap.rs
@@ -248,7 +248,7 @@ impl XWrap {
             _: *mut xlib::Display,
             _: *mut xlib::XErrorEvent,
         ) -> c_int {
-            eprintln!("ERROR: another window manager is already running");
+            tracing::error!("ERROR: another window manager is already running");
             ::std::process::exit(-1);
         }
         unsafe {

--- a/leftwm/src/bin/lefthk-worker.rs
+++ b/leftwm/src/bin/lefthk-worker.rs
@@ -1,8 +1,13 @@
 use lefthk_core::{config::Config, worker::Worker};
+use leftwm::utils;
+use tracing_subscriber::EnvFilter;
 use xdg::BaseDirectories;
 
 fn main() {
-    leftwm::utils::log::setup_logging();
+    tracing::subscriber::set_global_default(utils::log::get_subscribers(
+        EnvFilter::from_default_env(),
+    ))
+    .expect("Couldn't setup global subscriber (logger)");
 
     tracing::info!("lefthk-worker booted!");
 

--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -73,6 +73,7 @@ async fn main() -> Result<()> {
                 dbg!(&config);
             }
             config.check_mousekey(verbose);
+            config.check_log_level(verbose);
             #[cfg(not(feature = "lefthk"))]
             println!("\x1b[1;93mWARN: Ignoring checks on keybinds as you compiled for an external hot key daemon.\x1b[0m");
             #[cfg(feature = "lefthk")]

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -197,6 +197,7 @@ impl Default for Backend {
 #[serde(default)]
 pub struct Config {
     pub backend: Backend,
+    pub log_level: String,
     pub modkey: String,
     pub mousekey: Option<Modifier>,
     pub workspaces: Option<Vec<Workspace>>,

--- a/leftwm/src/config/checks.rs
+++ b/leftwm/src/config/checks.rs
@@ -3,6 +3,7 @@ use super::Config;
 use lefthk_core::xkeysym_lookup;
 #[cfg(feature = "lefthk")]
 use std::collections::HashSet;
+use tracing_subscriber::EnvFilter;
 
 impl Config {
     pub fn check_mousekey(&self, verbose: bool) {
@@ -20,6 +21,17 @@ impl Config {
             if verbose {
                 println!("Mousekey is okay.");
             }
+        }
+    }
+
+    pub fn check_log_level(&self, verbose: bool) {
+        if verbose {
+            println!("Trying to parse log_level.");
+        }
+        match EnvFilter::builder().parse(&self.log_level) {
+            Ok(_) if verbose => println!("Log level is ok."),
+            Ok(_) => {}
+            Err(err) => println!("Log level is invalid: {err}"),
         }
     }
 

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -215,6 +215,7 @@ impl Default for Config {
         let layouts = leftwm_layouts::layouts::Layouts::default();
 
         Self {
+            log_level: String::from("debug"),
             // Using Backend's feature fallback
             backend: Backend::default(),
             workspaces: Some(vec![]),


### PR DESCRIPTION
# Description
Add `log_level` to the config.ron options (replacing RUST_LOG env) to allow log level hot-swapping.

For available options, see the tracing [EnvFilter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) docs.

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
